### PR TITLE
Support relative dates/datetimes

### DIFF
--- a/iommi/datetime_parsing.py
+++ b/iommi/datetime_parsing.py
@@ -1,0 +1,118 @@
+from datetime import (
+    date,
+    datetime,
+    timedelta,
+)
+
+from iommi._web_compat import ValidationError
+
+
+def parse_relative_datetime(s, start_date=None):
+    result = parse_relative_date(s, start_date=start_date)
+    if result is None:
+        return None
+    return datetime.combine(result, datetime.now().time())
+
+
+def parse_relative_date(s, start_date=None):
+    period = s.strip()
+    weekday_symbols = ['wd', 'weekday', 'weekdays', 'bd', 'bankday', 'bankdays']
+    day_symbols = ['d', 'day', 'days']
+    week_symbols = ['w', 'wk', 'week', 'weeks']
+    month_symbols = ['m', 'mo', 'mon', 'month', 'months']
+    quarter_symbols = ['q', 'quarter', 'quarters']
+    year_symbols = ['y', 'yr', 'year', 'years']
+    period_symbols = weekday_symbols + day_symbols + week_symbols + month_symbols + quarter_symbols + year_symbols
+    neg = False
+    period = period.lower()
+    if period in ('today', 'now'):
+        period = '0d'
+        start_date = None
+    elif period == 'yesterday':
+        period = '-1d'
+        start_date = None
+    elif period == 'tomorrow':
+        period = '1d'
+        start_date = None
+    if period.endswith('ago'):
+        period = period[:-len('ago')].strip()
+        neg = True
+        if period.endswith('_'):
+            period = period[:-1]
+
+    sym = None
+    for symbol in period_symbols:
+        if period.endswith(symbol):
+            period = period[:-len(symbol)]
+            sym = symbol
+            break
+    d = None
+    if sym:
+        try:
+            count = int(period)
+        except ValueError:
+            raise ValidationError(f'"{s}" is not a valid relative date. "{period}" is not an integer.')
+        if neg:
+            count = -count
+        if start_date:
+            today = start_date
+        else:
+            today = date.today()
+        day = today.day
+        month = today.month
+        year = today.year
+        if sym in day_symbols:
+            if count >= 10000:
+                raise ValidationError(f'"{s}" is not a valid relative date. {count} is too big (max is 9999).')
+            d = today + timedelta(days=count)
+        elif sym in week_symbols:
+            if count >= 2000:
+                raise ValidationError(f'"{s}" is not a valid relative date. {count} is too big (max is 1999).')
+            d = today + timedelta(weeks=count)
+        elif sym in month_symbols or sym in quarter_symbols:
+            if sym in quarter_symbols:
+                if count >= 167:
+                    raise ValidationError(f'"{s}" is not a valid relative date. {count} is too big (max is 166).')
+                count *= 3
+            if count >= 500:
+                raise ValidationError(f'"{s}" is not a valid relative date. {count} is too big (max is 499).')
+            month += count
+            if month < 1 or month > 12:
+                (y, m) = divmod(month - 1, 12)
+                year += y
+                month = m + 1
+            valid = False
+            while not valid:
+                try:
+                    d = date(year, month, day)
+                    valid = True
+                except ValueError:
+                    day -= 1
+
+        elif sym in year_symbols:
+            if count >= 400:
+                raise ValidationError(f'"{s}" is not a valid relative date. {count} is too big (max is 399).')
+            year += count
+            valid = False
+            while not valid:
+                try:
+                    d = date(year, month, day)
+                    valid = True
+                except ValueError:
+                    day -= 1
+        elif sym in weekday_symbols:
+            weeks, days = divmod(count, 5)
+            d = today
+            weekday = d.weekday()
+            if weekday in [5, 6]:
+                d -= timedelta(days=weekday - 4)
+                weekday = 4
+            if weeks:
+                d += timedelta(days=weeks * 7)
+            if days:
+                d += timedelta(days=days)
+            new_weekday = d.weekday()
+            if new_weekday in [5, 6] or new_weekday < weekday:
+                d += timedelta(days=2)
+
+    return d

--- a/iommi/datetime_parsing__tests.py
+++ b/iommi/datetime_parsing__tests.py
@@ -1,0 +1,92 @@
+from datetime import (
+    date,
+    datetime,
+    timedelta,
+)
+
+import pytest
+import freezegun
+
+from iommi._web_compat import ValidationError
+from iommi.datetime_parsing import (
+    parse_relative_date,
+    parse_relative_datetime,
+)
+
+fake_now = datetime(2018, 2, 5, 7, 11, 13, 17)
+
+
+@pytest.fixture(autouse=True)
+def frozen_time():
+    with freezegun.freeze_time(
+        fake_now,
+        ignore=[
+            'tri.cassandra',
+            '_pytest.terminal',
+            '_pytest.runner',
+            'selenium',
+        ],
+    ) as f:
+        yield f
+
+
+@pytest.mark.parametrize(
+    'value, message',
+    [
+        ('foo days', '"foo days" is not a valid relative date. "foo " is not an integer.'),
+        ('10000 days', '"10000 days" is not a valid relative date. 10000 is too big (max is 9999).'),
+        ('2000 weeks', '"2000 weeks" is not a valid relative date. 2000 is too big (max is 1999).'),
+        ('500 months', '"500 months" is not a valid relative date. 500 is too big (max is 499).'),
+        ('500 quarters', '"500 quarters" is not a valid relative date. 500 is too big (max is 166).'),
+    ]
+)
+def test_parse_relative_date_error_conditions(value, message):
+    with pytest.raises(ValidationError) as e:
+        parse_relative_date(value)
+
+    assert e.value.message == message
+
+
+def test_parse_relative_date_error_condition_no_match():
+    assert parse_relative_date('foo') is None
+    assert parse_relative_datetime('foo') is None
+
+
+def test_parse_relative_date_relative():
+    today = date.today()
+
+    # past
+    assert parse_relative_date('yesterday') == (today - timedelta(days=1))
+    assert parse_relative_date('5 days ago') == (today - timedelta(days=5))
+    assert parse_relative_date('5 days_ago') == (today - timedelta(days=5))  # Weird, but the code was written for this case, so let's test it
+    assert parse_relative_date('5 weekdays ago') == (today - timedelta(days=7))
+    assert parse_relative_date('1 week ago') == (today - timedelta(days=7))
+    assert parse_relative_date('1 month ago') == (today - timedelta(days=31))
+    assert parse_relative_date('1 year ago') == (today - timedelta(days=365))
+    assert parse_relative_date('1 quarter ago') == date(2017, 11, 5)
+
+    # present
+    assert parse_relative_date('today') == today
+
+    # future
+    assert parse_relative_date('tomorrow') == (today + timedelta(days=1))
+    assert parse_relative_date('8 days') == (today + timedelta(days=8))
+    assert parse_relative_date('8 weekdays') == (today + timedelta(days=10))
+    assert parse_relative_date('1 week') == (today + timedelta(days=7))
+    assert parse_relative_date('1 month') == (today + timedelta(days=28))
+    assert parse_relative_date('1 year') == (today + timedelta(days=365))
+    assert parse_relative_date('1 quarter') == date(2018, 5, 5)
+
+    # start_date is ignored for "today"
+    assert parse_relative_date('today', start_date=date(2020, 3, 5)) == today
+
+    # using start_date
+    assert parse_relative_date('1d', start_date=date(2020, 3, 5)) == date(2020, 3, 6)
+
+
+def test_parse_relative_date_weekdays():
+    with freezegun.freeze_time('2018-02-02'):  # a friday
+        assert parse_relative_date('1 weekday') == (date.today() + timedelta(days=3))
+
+    with freezegun.freeze_time('2018-02-03'):  # a saturday
+        assert parse_relative_date('1 weekday') == (date.today() + timedelta(days=2))

--- a/iommi/templates/iommi/query/form.html
+++ b/iommi/templates/iommi/query/form.html
@@ -35,6 +35,7 @@
                             <li>Exclude a value: field_name!=value</li>
                             <li>You can also use &lt;, &gt;, &lt;= and &gt;= to find ranges of values: field_name&lt;10</li>
                             <li>To search for dates, use ISO8601 format: field_name>1969-07-20</li>
+                            <li>You can filter for relative dates: field_name < "10 days ago". Supported fields are days, months, years, quarters and weekdays. They can be negative and abbreviated from "10 days ago" to "-10d".</li>
                         </ul>
                     </div>
                 </td>

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4==4.7.1
 pytest==4.6.2
 pytest-django==3.4.8
+freezegun==0.3.15
 -rrequirements.txt


### PR DESCRIPTION
Suppport more time formats
Introduced Filter.parse() which is a hook point for handling special parsing in the query language
The query language will no longer try to convert to integers, floats and dates for you. You have to specify a parse() method. This also makes the query language much more flexible.