### PR TITLE
active is spelled is-active in bulma

### DIFF
--- a/iommi/style_bulma.py
+++ b/iommi/style_bulma.py
@@ -94,6 +94,7 @@ bulma_base = Style(
         tag='nav',
     ),
     MenuItem__a__attrs__class={'navbar-item': True},
+    MenuItem__active_class='is-active',
     DebugMenu=dict(
         tag='aside',
         attrs__class={


### PR DESCRIPTION
Exactly what is says on the tin.  The active menu item should be marked by class is-active and not active.