### PR TITLE
Render date fields as such (

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -415,11 +415,11 @@ uses).
 .. code:: python
     my_style = Style(iommi.style_bootstrap.style, Field__shortcuts__date__input__attrs_type='date')
 
-When you do that you will get Englisch language relative date parsing 
-(e.g. "yesterday, 3 days ago") for free, because iommi used to use a 
+When you do that you will get English language relative date parsing 
+(e.g. "yesterday", "3 days ago") for free, because iommi used to use a 
 text based input control and the parser is applied no matter what 
 (its just that when using the default date picker control it will 
-always only see ISO-8601 dates).
+always only see ISO-8601 dates). 
 
 Tables
 ------

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -404,6 +404,23 @@ Pass a template name or a `Template` object to the `input` namespace:
         fields__year__input__template=Template('{{ field.attrs }}'),
     )
 
+How do I change how fields are rendered everywhere in my project?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Define a custom style and override the appropriate fields.  For
+example here is how you could change `Field.date` to use a text
+based input control (as opposed to the date picker that `input type='date'`
+uses).  
+
+.. code:: python
+    my_style = Style(iommi.style_bootstrap.style, Field__shortcuts__date__input__attrs_type='date')
+
+When you do that you will get Englisch language relative date parsing 
+(e.g. "yesterday, 3 days ago") for free, because iommi used to use a 
+text based input control and the parser is applied no matter what 
+(its just that when using the default date picker control it will 
+always only see ISO-8601 dates).
+
 Tables
 ------
 

--- a/examples/examples/views.py
+++ b/examples/examples/views.py
@@ -269,6 +269,8 @@ class KitchenForm(Form):
 
     checkbox = Field.boolean()
 
+    date = Field.date()
+
 
 class SinkForm(Form):
     class Meta:

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -1043,7 +1043,7 @@ class Field(Part):
     @classmethod
     @class_shortcut(
         parse=date_parse,
-        render_value=date_render_value
+        render_value=date_render_value,
     )
     def date(cls, call_target=None, **kwargs):
         return call_target(**kwargs)

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -1044,6 +1044,7 @@ class Field(Part):
     @class_shortcut(
         parse=date_parse,
         render_value=date_render_value,
+        input__attrs__type='date'
     )
     def date(cls, call_target=None, **kwargs):
         return call_target(**kwargs)

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -1043,8 +1043,7 @@ class Field(Part):
     @classmethod
     @class_shortcut(
         parse=date_parse,
-        render_value=date_render_value,
-        input__attrs__type='date'
+        render_value=date_render_value
     )
     def date(cls, call_target=None, **kwargs):
         return call_target(**kwargs)

--- a/iommi/style_base.py
+++ b/iommi/style_base.py
@@ -39,6 +39,7 @@ base = Style(
             choice_queryset=dict(
                 input__template='iommi/form/choice_select2.html',
             ),
+            date__input__attrs__type='date',
             radio=dict(
                 input__template='iommi/form/radio.html',
             ),


### PR DESCRIPTION
(Most modern browsers but Safari on Mac OS support it).  And even Safari degrades gracefully to a text control.  And the existing date implementation already does the right thing (convert to and fro ISO format).