### PR TITLE
Support for optgroups

### DIFF
--- a/examples/examples/views.py
+++ b/examples/examples/views.py
@@ -275,8 +275,8 @@ class KitchenForm(Form):
 
     choice_with_groups = Field.choice(
         choices=['a1', 'a2', 'a3', 'b1', 'b2', 'b3', 'X'],
-        choice_to_optgroup=lambda choice: choice[0] if choice[0].islower(
-        ) else None
+        choice_to_optgroup=lambda choice, **_:
+            choice[0] if choice[0].islower() else None
     )
 
 

--- a/examples/examples/views.py
+++ b/examples/examples/views.py
@@ -271,6 +271,14 @@ class KitchenForm(Form):
 
     date = Field.date()
 
+    choice = Field.choice(choices=['a1', 'a2', 'a3', 'b1', 'b2', 'b3', 'X'])
+
+    choice_with_groups = Field.choice(
+        choices=['a1', 'a2', 'a3', 'b1', 'b2', 'b3', 'X'],
+        choice_to_optgroup=lambda choice: choice[0] if choice[0].islower(
+        ) else None
+    )
+
 
 class SinkForm(Form):
     class Meta:

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -15,6 +15,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    Optional
 )
 
 from django.db.models import (
@@ -498,6 +499,7 @@ class Field(Part):
 
     choices: Callable[..., List[Any]] = Refinable()  # choices is evaluated, but in a special way so gets no EvaluatedRefinable type
     choice_to_option: Callable[..., Tuple[Any, str, str, bool]] = Refinable()
+    choice_to_optgroup: Optional[Callable[[Any], str]] = Refinable()
     search_fields = Refinable()
     errors: Errors = Refinable()
 
@@ -530,6 +532,7 @@ class Field(Part):
         non_editable_input__call_target=Fragment,
         non_editable_input__attrs__type=None,
         initial=MISSING,
+        choice_to_optgroup=None,
     )
     def __init__(self, **kwargs):
         """
@@ -562,6 +565,7 @@ class Field(Part):
         :param read_from_instance: Callback to retrieve value from edited instance. Invoked with parameters field and instance.
         :param write_to_instance: Callback to write value to instance. Invoked with parameters field, instance and value.
         :param choice_to_option: Callback to generate the choice data given a choice value. It will get the keyword arguments `form`, `field` and `choice`. It should return a 4-tuple: `(choice, internal_value, display_name, is_selected)`
+        :param choice_to_optgroup Callback to generate the optgroup for the given choice.  choice -> string|None where None means that value should not be grouped.
         """
 
         model_field = kwargs.get('model_field')
@@ -827,6 +831,8 @@ class Field(Part):
 
     @property
     def choice_tuples(self):
+        # Why does this cache exist?  choice_tuples is only called once to render
+        # the form element isn't it?
         if self._choice_tuples is not None:
             return self._choice_tuples
 
@@ -837,6 +843,25 @@ class Field(Part):
             self._choice_tuples.append(self.choice_to_option(form=self.form, field=self, choice=choice) + (i + 1,))
 
         return self._choice_tuples
+
+    @property
+    def grouped_choice_tuples(self):
+        if self.choice_to_optgroup is None:
+            return [(None, self.choice_tuples)]
+        else:
+            groups = []
+            current_group_name = None
+            current_group = []
+            groups.append((current_group_name, current_group))
+            for choice_tuple in self.choice_tuples:
+                choice = choice_tuple[0]
+                group_name = self.choice_to_optgroup(choice)
+                if current_group_name != group_name:
+                    current_group_name = group_name
+                    current_group = []
+                    groups.append((current_group_name, current_group))
+                current_group.append(choice_tuple)
+            return groups
 
     @classmethod
     def from_model(cls, model, model_field_name=None, model_field=None, **kwargs):

--- a/iommi/templates/iommi/form/choice.html
+++ b/iommi/templates/iommi/form/choice.html
@@ -1,5 +1,13 @@
 <select{{ field.input.attrs }}>
-    {% for choice in field.choice_tuples %}
-        <option value="{{ choice.1 }}" {% if choice.3 %}selected="selected"{% endif %}>{{ choice.2 }}</option>
+    {% for optgroup, choice_tuples in field.grouped_choice_tuples %}
+        {% if optgroup %}
+            <optgroup label="{{optgroup}}">
+        {% endif %}
+            {% for choice in choice_tuples %}
+                <option value="{{ choice.1 }}" {% if choice.3 %}selected="selected"{% endif %}>{{ choice.2 }}</option>
+            {% endfor %}
+        {% if optgroup %}
+            </optgroup>
+        {% endif %}
     {% endfor %}
 </select>


### PR DESCRIPTION
What it says on the tin.  I chose not to support django forms API (where the choices are interpreted differently if the values are lists or tuples), even so it leads to pretty callsites. 

 In practice I found the proposed API more eh practical ;-)

Existing test cases pass and the adjusted form kitchen sink does what you expect.

BUT note the comment on the existing choice_tuples method.