### PR TITLE
Differentiate between primary and other actions

### DIFF
--- a/iommi/action.py
+++ b/iommi/action.py
@@ -54,6 +54,20 @@ class Action(Fragment):
 
         # Button
         Action.button(attrs__value='Button title!')
+
+        # A submit button
+        Action.submit(display_name='Do this')
+
+        # The primary submit button on a form, unnecessary
+        # most of the time as a form includes a submit
+        # button by default.
+        Action.primary()
+
+        # A button styled as primary but not using
+        # the submit html element, but the button
+        # element.
+        Action.primary(call_target__attribute='button')
+
     """
 
     group: str = EvaluatedRefinable()
@@ -107,6 +121,13 @@ class Action(Fragment):
         display_name=gettext_lazy('Submit'),
     )
     def submit(cls, call_target=None, **kwargs):
+        return call_target(**kwargs)
+
+    @classmethod
+    @class_shortcut(
+        call_target__attribute='submit',
+    )
+    def primary(cls, call_target=None, **kwargs):
         return call_target(**kwargs)
 
     @classmethod

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -1256,7 +1256,7 @@ class Form(Part):
         attrs__action='',
         attrs__method='post',
         attrs__enctype='multipart/form-data',
-        actions__submit__call_target__attribute='submit',
+        actions__submit__call_target__attribute='primary',
         auto=EMPTY,
         h_tag__call_target=Header,
     )

--- a/iommi/style_bootstrap.py
+++ b/iommi/style_bootstrap.py
@@ -73,13 +73,19 @@ bootstrap_base = Style(
     ),
     Action=dict(
         shortcuts=dict(
+            # In bootstrap one must choose a button style (secondary, success, ...)
+            # otherwise the styling is roughly identical to text.
             button__attrs__class={
                 'btn': True,
+                'btn-secondary': True,
+            },
+            primary__attrs__class={
                 'btn-primary': True,
+                'btn-secondary': False,
             },
             delete__attrs__class={
-                'btn-primary': False,
                 'btn-danger': True,
+                'btn-secondary': False,
             },
         ),
     ),

--- a/iommi/style_bulma.py
+++ b/iommi/style_bulma.py
@@ -72,12 +72,16 @@ bulma_base = Style(
     ),
     Action=dict(
         shortcuts=dict(
+            # In bulma the most neutral button styling is button, which
+            # gets you a button that's just an outline.
             button__attrs__class={
                 'button': True,
             },
             delete__attrs__class={
-                'button': True,
                 'is-danger': True,
+            },
+            primary__attrs__class={
+                'is-primary': True,
             },
         ),
     ),

--- a/iommi/style_foundation.py
+++ b/iommi/style_foundation.py
@@ -28,7 +28,11 @@ foundation_base = Style(
     Action=dict(
         shortcuts=dict(
             button__attrs__class__button=True,
+            button__attrs__class__secondary=True,
+            primary__attrs__class__primary=True,
+            primary__attrs__class__secondary=False,
             delete__attrs__class__alert=True,
+            delete__attrs__class__secondary=False,
         ),
     ),
     Menu=dict(

--- a/iommi/style_semantic_ui.py
+++ b/iommi/style_semantic_ui.py
@@ -62,6 +62,7 @@ semantic_ui_base = Style(
                 'ui': True,
                 'button': True,
             },
+            primary__attrs__class__primary=True,
             delete__attrs__class__negative=True,
         ),
     ),

--- a/iommi/table.py
+++ b/iommi/table.py
@@ -1437,6 +1437,10 @@ class Table(Part, Tag):
         attrs__style=EMPTY,
 
         paginator__call_target=Paginator,
+        # The filter action on a table will often not be the primary
+        # action button on the page.  So let's use the secondary
+        # style
+        query__form__actions__submit__call_target=Action.button
     )
     def __init__(self, *, columns: Namespace = None, _columns_dict=None, model=None, rows=None, bulk=None, header=None, query=None, row=None, actions: Namespace = None, auto, title=MISSING, paginator, **kwargs):
         """


### PR DESCRIPTION
This is similar to the already existing Action.delete. Form's standard button is now primary.  But the button used on a table's query form is not, on the assumption that on many pages that will not be the default action.  If we had a standard Action.info or similar I would have used that -- maybe another day.