### PR TITLE
Include locale info in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include requirements.txt
 exclude tests/*
 exclude iommi/*__tests.py
 recursive-include iommi/templates *
+recursive-include iommi/locale *


### PR DESCRIPTION
I finally figured out why my app wasn't localized properly... The iommi package didn't include the locale.