### PR TITLE
Tests to demo a bug.

### DIFF
--- a/iommi/query.py
+++ b/iommi/query.py
@@ -1,4 +1,5 @@
 import operator
+from copy import deepcopy
 from functools import reduce
 from typing import (
     Type,
@@ -585,6 +586,11 @@ class Query(Part):
         self.query_advanced_value = None
         self.query_error = None
 
+        # It's not safe to modify kwargs deeply! reinvoke() is evil.
+        freetext_config = kwargs.get('form', {}).get('fields', {}).get('freetext', {})
+        kwargs = deepcopy(kwargs)
+        kwargs.get('form', {}).get('fields', {}).pop('freetext', {})
+
         super(Query, self).__init__(
             model=model,
             rows=rows,
@@ -602,6 +608,7 @@ class Query(Part):
             required=False,
             include=False,
             help__include=False,
+            **freetext_config
         )
 
         for name, filter in items(declared_members(self).filters):

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -897,6 +897,36 @@ def test_invalid_syntax_query():
 
 
 @pytest.mark.django_db
+def test_query_form_freetext():
+    class TestTable(Table):
+        b = Column(filter__include=True, filter__freetext=True)
+
+    expected_html = """
+        <span class="iommi_query_form_simple">
+            <div><label for="id_freetext">Search</label><input id="id_freetext" name="freetext" type="text" value=""></div>
+        </span>
+    """
+    verify_table_html(table=TestTable(rows=TFoo.objects.all()[:1]), find=dict(class_="iommi_query_form_simple"), expected_html=expected_html)
+
+
+@pytest.mark.django_db
+def test_query_form_freetext__exclude_label():
+    # As of right now this test does not pass!  But I claim it should.
+    class TestTable(Table):
+        b = Column(filter__include=True, filter__freetext=True)
+
+        class Meta:
+            query__form__fields__freetext__label__include = False
+
+    expected_html = """
+        <span class="iommi_query_form_simple">
+            <div><input id="id_freetext" name="freetext" type="text" value=""></div>
+        </span>
+    """
+    verify_table_html(table=TestTable(rows=TFoo.objects.all()[:1]), find=dict(class_="iommi_query_form_simple"), expected_html=expected_html)
+
+
+@pytest.mark.django_db
 def test_query():
     assert TFoo.objects.all().count() == 0
 

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -927,6 +927,23 @@ def test_query_form_freetext__exclude_label():
 
 
 @pytest.mark.django_db
+def test_query_form_foo__exclude_label():
+    # As of right now this test does not pass!  But I claim it should.
+    class TestTable(Table):
+        b = Column(filter__include=True)
+
+        class Meta:
+            query__form__fields__b__label__include = False
+
+    expected_html = """
+        <span class="iommi_query_form_simple">
+            <div><input id="id_b" name="b" type="text" value=""></div>
+        </span>
+    """
+    verify_table_html(table=TestTable(rows=TFoo.objects.all()[:1]), find=dict(class_="iommi_query_form_simple"), expected_html=expected_html)
+
+
+@pytest.mark.django_db
 def test_query():
     assert TFoo.objects.all().count() == 0
 


### PR DESCRIPTION
I haven't investigated the cause.

- [X] test_query_form_freetext passes

- [ ] test_query_form_freetext__exclude_label does NOT!  In fact the generated form does not contain an input element at all...