### PR TITLE
Make table.rows do one thing and introduce new names for the other things.

### DIFF
--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -40,7 +40,7 @@ from iommi.table import (
     Column,
     datetime_formatter,
     default_cell_formatter,
-    order_by_on_list,
+    ordered_by_on_list,
     register_cell_formatter,
     SELECT_DISPLAY_NAME,
     Struct,
@@ -1802,17 +1802,17 @@ def test_ordering():
     # no ordering
     t = Table(auto__model=TFoo)
     t = t.bind(request=req('get'))
-    assert not t.rows.query.order_by
+    assert not t.sorted_rows.query.order_by
 
     # ordering from GET parameter
     t = Table(auto__model=TFoo)
     t = t.bind(request=req('get', order='a'))
-    assert list(t.rows.query.order_by) == ['a']
+    assert list(t.sorted_rows.query.order_by) == ['a']
 
     # default ordering
     t = Table(auto__model=TFoo, default_sort_order='b')
     t = t.bind(request=req('get', order='b'))
-    assert list(t.rows.query.order_by) == ['b']
+    assert list(t.sorted_rows.query.order_by) == ['b']
 
 
 @pytest.mark.django_db
@@ -2836,11 +2836,10 @@ def test_order_by_on_list_nested():
         Struct(foo=Struct(bar='a')),
     ]
 
-    sorted_rows = rows[:]
-    order_by_on_list(sorted_rows, 'foo__bar')
+    sorted_rows = ordered_by_on_list(rows, 'foo__bar')
     assert sorted_rows == list(reversed(rows))
 
-    order_by_on_list(sorted_rows, lambda x: x.foo.bar)
+    sorted_rows = ordered_by_on_list(rows, lambda x: x.foo.bar)
     assert sorted_rows == list(reversed(rows))
 
 


### PR DESCRIPTION
Idea: Introduce separate fields for the different stages (initial rows, sorted rows, filtered rows, visible rows).

Why is that good?  Because it means we bind / set each field once and the semantics does not depend on where we are in the life-cycle of the table object (mutation is evil).

Indeed I ended up writing this patch because I had a bug trying to write a different patch, which happened because
I hadn't realized that self.paginator is used to rewrite self.rows to be just the visible rows.

As much as table.rows is considered to be a public API it changes the API (see the change in one of the tests).  Now
it didn't seem to have a clearly documented semantics so maybe this is fine.  At the moment I also haven't documented
the new fields.  Which is fine as long as table is primarily there as a way to display values and not to get them out
again.  But we could also consider documenting the fields better.

Testing: All tests still pass.  Also the table examples seem to still behave the same as before (but I only did
some superficial testing, without trying to exhaustively hit every interaction on every page).