### PR TITLE
Select on lists

### DIFF
--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -708,7 +708,7 @@ def test_column_presets(NoSortTable):
                     <td> <a href="http://yada/delete/"> <i class="fa fa-lg fa-trash-o"/> Delete </a> </td>
                     <td> <a href="http://yada/download/"> <i class="fa fa-download fa-lg"/> Download </a> </td>
                     <td> <a href="http://yada/run/"> Run </a> </td>
-                    <td> <input class="checkbox" name="pk_123" type="checkbox"/> </td> <td> <i class="fa fa-check" title="Yes" /> </td>
+                    <td> <input class="checkbox" name="pk_0" type="checkbox"/> </td> <td> <i class="fa fa-check" title="Yes" /> </td>
                     <td> <a href="http://yadahada/"> Yadahada name </a> </td>
                     <td class="rj"> 123 </td>
                 </tr>

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -42,7 +42,7 @@ from iommi.table import (
     default_cell_formatter,
     ordered_by_on_list,
     register_cell_formatter,
-    SELECT_DISPLAY_NAME,
+    make_select_display_name,
     Struct,
     Table,
     yes_no_formatter,
@@ -684,7 +684,9 @@ def test_column_presets(NoSortTable):
             number=123
         )
     ]
-    verify_table_html(table=TestTable(rows=rows), expected_html="""
+    table = TestTable(rows=rows)
+
+    verify_table_html(table=table, expected_html="""
         <table class="table" data-endpoint="/tbody">
             <thead>
                 <tr>
@@ -713,7 +715,7 @@ def test_column_presets(NoSortTable):
                     <td class="rj"> 123 </td>
                 </tr>
             </tbody>
-        </table>""".format(SELECT_DISPLAY_NAME))
+        </table>""".format(make_select_display_name(table)))
 
 
 @pytest.mark.django_db

--- a/iommi/templates/iommi/table/js_select_all.html
+++ b/iommi/templates/iommi/table/js_select_all.html
@@ -1,4 +1,27 @@
 <script>
+    // Polyfill for closest() on IE11. Remove when we drop support for IE11.
+
+    if (!Element.prototype.matches) {
+        Element.prototype.matches =
+            Element.prototype.msMatchesSelector ||
+            Element.prototype.webkitMatchesSelector;
+    }
+
+    if (!Element.prototype.closest) {
+        Element.prototype.closest = function (s) {
+            var el = this;
+
+            do {
+                if (Element.prototype.matches.call(el, s)) return el;
+                el = el.parentElement || el.parentNode;
+            } while (el !== null && el.nodeType === 1);
+            return null;
+        };
+    }
+
+    // End polyfill for IE11
+
+
     function iommi_table_js_select_all(base, has_paginator) {
         var table = base.closest('table');
         var tbody = table.querySelector('tbody');

--- a/iommi/templates/iommi/table/js_select_all.html
+++ b/iommi/templates/iommi/table/js_select_all.html
@@ -1,29 +1,33 @@
 <script>
-    function iommi_table_js_select_all(base) {
-        // 4 times parentNode to go from i -> th -> tr -> table
-        var tbody = base.parentNode.parentNode.parentNode.parentNode.querySelector('tbody');
+    function iommi_table_js_select_all(base, has_paginator) {
+        var table = base.closest('table');
+        var tbody = table.querySelector('tbody');
+        // Select all checkboxes on this page
         Array.prototype.forEach.call(tbody.querySelectorAll('.checkbox'), function(el, i) {
             el.click();
         });
 
-        var has_paginator = {% if table.paginator.is_paginated %}true{% else %}false{% endif %};
-
+        // If there are multiple pages 
         if (has_paginator) {
+            // If we haven't done so already offer to select everything 
             if (tbody.querySelector('.select_all_pages_q') === null) {
                 tbody.querySelector('tr').insertAdjacentHTML('beforebegin', '<tr><td colspan="99" style="text-align: center" class="select_all_pages_q">All items on this page are selected. <a onclick="iommi_table_js_select_all_pages(this)" href="#">Select all items</a></td></tr>'
                 )
             }
             else {
-                tbody.querySelector('.select_all_pages_q').parentNode.parentNode.removeChild(tbody.querySelector('.select_all_pages_q').parentNode);
-                var form = base.parentNode.parentNode.parentNode.parentNode.parentNode;
+                // Otherwise the select all button was hit again (and nothing should be selected)
+                // Hide the select everything again.
+                var row_with_select_all = tbody.querySelector('.select_all_pages_q').closest('tr');
+                row_with_select_all.parentNode.removeChild(row_with_select_all);
+                var form = base.closest('form');
                 form.querySelector('.all_pks').value = 0;
             }
         }
     }
 
     function iommi_table_js_select_all_pages(base) {
-        var form = base.parentNode.parentNode.parentNode.parentNode.parentNode;
-        var tbody = base.parentNode.parentNode.parentNode.parentNode.querySelector('tbody');
+        var form = base.closest('form');
+        var tbody = form.querySelector('tbody');
         tbody.querySelector('.select_all_pages_q').textContent = 'All items selected';
         form.querySelector('.all_pks').value = 1;
     }


### PR DESCRIPTION
Support select on lists (and custom bulk_actions in the presense of those).

To that end there is a new function `table.selection()` which returns the selected rows as either a `queryset` or a `list` according to the type of `rows`.

`bulk_queryset` is now implemented in terms of `selection` and does the filtering according to `bulk_filter` and `bulk_exclude`.

There is a new example to showcase the functionality.  