### PR TITLE
Additional fields in query forms

### DIFF
--- a/examples/examples/table_examples.py
+++ b/examples/examples/table_examples.py
@@ -21,6 +21,7 @@ from iommi import (
     Column,
     html,
     Table,
+    Field,
 )
 
 examples = []
@@ -181,6 +182,18 @@ def table_post_handler_on_lists(request):
     return FooTable(rows=foos)
 
 
+@example(gettext('You can have extra fields in your form that the query will ignore'))
+def extra_fields(request):
+    class FooTable(Table):
+        name = Column(filter__include=True)
+
+    table = FooTable(rows=Foo.objects.all(),
+                     query__form__fields__my_extra_field=Field(attr=None, initial="Hello World")
+                     ).bind(request=request)
+    print(table.query.form.fields.my_extra_field.value)
+    return table
+
+
 class IndexPage(ExamplesPage):
     header = html.h1('Table examples')
 
@@ -211,4 +224,5 @@ urlpatterns = [
     path('example_6/', example_6_view),
     path('example_7/', table_two),
     path('example_8/', table_post_handler_on_lists),
+    path('example_9/', extra_fields),
 ]

--- a/iommi/query.py
+++ b/iommi/query.py
@@ -911,7 +911,7 @@ class Query(Part):
             result = [
                 expr(field, field.is_list, field.value)
                 for field in values(form.fields)
-                if field._name != FREETEXT_SEARCH_NAME and field.value not in (None, '', [])
+                if field._name != FREETEXT_SEARCH_NAME and field._name in self.filters and field.value not in (None, '', [])
             ]
 
             if FREETEXT_SEARCH_NAME in form.fields:


### PR DESCRIPTION
Query forms can now have additional fields, that are ignored by the filter handling code (when you want to do additional filtering outside of the query logic).