### PR TITLE
Cleanup of how errors are handled

### DIFF
--- a/iommi/admin.py
+++ b/iommi/admin.py
@@ -425,7 +425,7 @@ class LoginForm(Form):
                     auth.login(request, user)
                     return HttpResponseRedirect(request.GET.get('next', '/'))
 
-                form.errors.add(gettext('Unknown username or password'))
+                form.add_error(gettext('Unknown username or password'))
 
 
 class LoginPage(Page):

--- a/iommi/error.py
+++ b/iommi/error.py
@@ -6,13 +6,12 @@ from tri_declarative import (
 from iommi.reinvokable import reinvokable
 
 
-class Errors(set):
+class Errors:
     @dispatch(
         attrs=EMPTY,
     )
     @reinvokable
-    def __init__(self, *, parent, attrs, errors=None, template=None):
-        super(Errors, self).__init__(errors or [])
+    def __init__(self, *, parent, attrs, template=None):
         self._parent = parent
         self.attrs = attrs
         self.template = template
@@ -22,13 +21,16 @@ class Errors(set):
         return self.__html__()
 
     def __bool__(self):
-        return len(self) != 0
+        # This function is needed because we want to be able to do {% if foo.errors %} in templates
+        # noinspection PyProtectedMember
+        return len(self._parent._errors) != 0
 
     def __html__(self):
         if not self:
             return ''
 
         from iommi import Fragment
+        # noinspection PyProtectedMember
         return Fragment(
             _name='error',
             tag='ul',
@@ -39,6 +41,6 @@ class Errors(set):
                     tag='li',
                     children__text=error,
                 )
-                for i, error in enumerate(sorted(self))
+                for i, error in enumerate(sorted(self._parent._errors))
             },
         ).bind(parent=self._parent).__html__()

--- a/iommi/error__tests.py
+++ b/iommi/error__tests.py
@@ -1,16 +1,28 @@
-from iommi import html
+from tri_struct import Struct
+
+from iommi import (
+    Form,
+    html,
+)
 from iommi._web_compat import Template
 from iommi.error import Errors
+from tests.helpers import req
 
 
 def test_errors_rendering():
-    errors = Errors(parent=None, errors={'foo', 'bar'}, attrs__foo='foo')
-    assert errors
-    assert errors.__html__() == '<ul foo="foo"><li>bar</li><li>foo</li></ul>'
+    form = Form(errors__attrs__foo='foo').bind(request=req('get'))
+    form.add_error('foo')
+    form.add_error('bar')
+    assert form.errors
+    assert form.errors.__html__() == '<ul foo="foo"><li>bar</li><li>foo</li></ul>'
 
 
 def test_errors_empty_rendering():
-    errors = Errors(parent=None, errors=set())
+    parent = Struct(
+        _errors=set(),
+        _is_bound=True,
+    )
+    errors = Errors(parent=parent)
     assert not errors
     assert errors.__html__() == ''
 
@@ -18,7 +30,8 @@ def test_errors_empty_rendering():
 def test_error_render_in_debug(settings):
     settings.DEBUG = True
     parent = html.p('foo').bind()
-    errors = Errors(parent=parent, errors={'foo', 'bar'})
+    parent._errors = {'foo', 'bar'}
+    errors = Errors(parent=parent)
     assert errors
     assert errors.__html__() == (
         '<ul data-iommi-path="error" data-iommi-type="Fragment">'
@@ -29,6 +42,8 @@ def test_error_render_in_debug(settings):
 
 
 def test_errors_rendering_template():
-    errors = Errors(parent=None, errors={'foo', 'bar'}, template=Template('foo'))
-    assert errors
-    assert errors.__html__() == 'foo'
+    form = Form(errors__template=Template('foo')).bind(request=req('get'))
+    form.add_error('foo')
+    form.add_error('bar')
+    assert form.errors
+    assert form.errors.__html__() == 'foo'


### PR DESCRIPTION
This makes the set of errors be `_errors`, while `errors` is now an instance of `Errors` that is used for rendering and not adding errors. To add an error to a `Field` or `Form` use the `add_error` methods