### PR TITLE
include=False on a Column should imply not generating the query filter and bulk field

### DIFF
--- a/iommi/table.py
+++ b/iommi/table.py
@@ -1733,6 +1733,16 @@ class Table(Part, Tag):
                 # Special case for entire table not sortable
                 column.sortable = False
 
+        # If the column is not included, the down stream query filters and bulk fields should also be gone
+        declared_query_filters = self._declared_members.query._declared_members.filters if self._declared_members.get('query') is not None else {}
+        declared_bulk_fields = self._declared_members.bulk._declared_members.fields if self._declared_members.get('bulk') is not None else {}
+        for name, column in items(self._declared_members.columns):
+            if column.include is False:
+                if name in declared_query_filters:
+                    declared_query_filters[name].include = False
+                if name in declared_bulk_fields:
+                    declared_bulk_fields[name].include = False
+
         self._bind_query()
         self._bind_bulk_form()
         self._bind_headers()

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -2160,14 +2160,21 @@ def test_dunder_name_for_column():
     assert list(table.query.form.fields.keys()) == ['foo', 'foo__a']
 
 
+@pytest.mark.django_db
 def test_render_column_attribute():
     class FooTable(Table):
+        class Meta:
+            model = TBar
+
         a = Column()
         b = Column(render_column=False)
         c = Column(render_column=lambda column, **_: False)
+        d = Column(filter__include=True, include=False)
 
     t = FooTable()
     t = t.bind(request=None)
+
+    assert not keys(t.query.filters)
 
     assert list(t.columns.keys()) == ['a', 'b', 'c']
     assert [k for k, v in items(t.columns) if v.render_column] == ['a']


### PR DESCRIPTION
If you want to not render a column but still want the filters, use the render_column=False feature.