### PR TITLE
Broken multiselect on empty list

### DIFF
--- a/iommi/form.py
+++ b/iommi/form.py
@@ -243,7 +243,19 @@ def choice_is_valid(field, parsed_data, **_):
 
 def choice_choice_to_option(form, field, choice):
     del form
-    return choice, "%s" % choice, "%s" % choice, choice == field.value
+    return (
+        choice,
+        "%s" % choice,
+        "%s" % choice,
+        (
+            choice == field.value
+            if not field.is_list
+            else (
+                    field.value is not None
+                    and choice in field.value
+            )
+        )
+    )
 
 
 def choice_parse(form, field, string_value):
@@ -329,7 +341,19 @@ def choice_queryset__parse(field, string_value, **_):
 
 
 def choice_queryset__choice_to_option(field, choice, **_):
-    return choice, choice.pk, "%s" % choice, choice == field.value
+    return (
+        choice,
+        choice.pk,
+        "%s" % choice,
+        (
+            choice == field.value
+            if not field.is_list
+            else (
+                    field.value is not None
+                    and choice in field.value
+            )
+        )
+    )
 
 
 datetime_iso_formats = [
@@ -423,14 +447,6 @@ def email_parse(string_value, **_):
 
 def phone_number_is_valid(parsed_data, **_):
     return re.match(r'^\+\d{1,3}(([ \-])?\(\d+\))?(([ \-])?\d+)+$', parsed_data, re.IGNORECASE), 'Please use format +<country code> (XX) XX XX. Example of US number: +1 (212) 123 4567 or +1 212 123 4567'
-
-
-def multi_choice_choice_to_option(field, choice, **_):
-    return choice, "%s" % choice, "%s" % choice, field.value and choice in field.value
-
-
-def multi_choice_queryset_choice_to_option(field, choice, **_):
-    return choice, choice.pk, "%s" % choice, field.value and choice in field.value
 
 
 def default_input_id(field, **_):
@@ -1037,7 +1053,6 @@ class Field(Part):
     @class_shortcut(
         call_target__attribute='choice',
         input__attrs__multiple=True,
-        choice_to_option=multi_choice_choice_to_option,
         is_list=True,
     )
     def multi_choice(cls, call_target=None, **kwargs):
@@ -1047,7 +1062,6 @@ class Field(Part):
     @class_shortcut(
         call_target__attribute='choice_queryset',
         input__attrs__multiple=True,
-        choice_to_option=multi_choice_queryset_choice_to_option,
         is_list=True,
     )
     def multi_choice_queryset(cls, call_target=None, **kwargs):

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -991,6 +991,7 @@ class Field(Part):
         empty_label='---',
         is_valid=choice_is_valid,
         choice_to_option=choice_choice_to_option,
+        input__attrs__multiple=lambda field, **_: True if field.is_list else None,
         parse=choice_parse,
     )
     def choice(cls, call_target=None, **kwargs):
@@ -1052,7 +1053,6 @@ class Field(Part):
     @classmethod
     @class_shortcut(
         call_target__attribute='choice',
-        input__attrs__multiple=True,
         is_list=True,
     )
     def multi_choice(cls, call_target=None, **kwargs):
@@ -1061,7 +1061,6 @@ class Field(Part):
     @classmethod
     @class_shortcut(
         call_target__attribute='choice_queryset',
-        input__attrs__multiple=True,
         is_list=True,
     )
     def multi_choice_queryset(cls, call_target=None, **kwargs):

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -53,6 +53,7 @@ from iommi.endpoint import (
 )
 from iommi.form import (
     bool_parse,
+    choice_choice_to_option,
     create_or_edit_object_redirect,
     datetime_iso_formats,
     datetime_parse,
@@ -64,7 +65,6 @@ from iommi.form import (
     FULL_FORM_FROM_REQUEST,
     INITIALS_FROM_GET,
     int_parse,
-    multi_choice_choice_to_option,
     register_field_factory,
     render_template,
     time_parse,
@@ -2083,21 +2083,25 @@ def test_shortcut_to_subclass():
 
 
 def test_multi_choice_choice_to_option():
+    form = Struct()
     field = Struct(
         value=[1, 2],
+        is_list=True,
     )
-    assert multi_choice_choice_to_option(field, 1) == (1, '1', '1', True)
-    assert multi_choice_choice_to_option(field, 2) == (2, '2', '2', True)
-    assert multi_choice_choice_to_option(field, 3) == (3, '3', '3', False)
+    assert choice_choice_to_option(form, field, 1) == (1, '1', '1', True)
+    assert choice_choice_to_option(form, field, 2) == (2, '2', '2', True)
+    assert choice_choice_to_option(form, field, 3) == (3, '3', '3', False)
 
 
 def test_multi_choice_choice_to_option_empty_values():
+    form = Struct()
     field = Struct(
         value=[],
+        is_list=True,
     )
-    assert multi_choice_choice_to_option(field, 1) == (1, '1', '1', False)
-    assert multi_choice_choice_to_option(field, 2) == (2, '2', '2', False)
-    assert multi_choice_choice_to_option(field, 3) == (3, '3', '3', False)
+    assert choice_choice_to_option(form, field, 1) == (1, '1', '1', False)
+    assert choice_choice_to_option(form, field, 2) == (2, '2', '2', False)
+    assert choice_choice_to_option(form, field, 3) == (3, '3', '3', False)
 
 
 def test_multi_choice_choice_tuples():

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2091,6 +2091,43 @@ def test_multi_choice_choice_to_option():
     assert multi_choice_choice_to_option(field, 3) == (3, '3', '3', False)
 
 
+def test_multi_choice_choice_to_option_empty_values():
+    field = Struct(
+        value=[],
+    )
+    assert multi_choice_choice_to_option(field, 1) == (1, '1', '1', False)
+    assert multi_choice_choice_to_option(field, 2) == (2, '2', '2', False)
+    assert multi_choice_choice_to_option(field, 3) == (3, '3', '3', False)
+
+
+def test_multi_choice_choice_tuples():
+    class MyForm(Form):
+        foo = Field.multi_choice(
+            choices=list('abc'),
+            initial=list('b'),
+        )
+
+    assert MyForm().bind().fields.foo.choice_tuples == [
+        ('a', 'a', 'a', False, 1),
+        ('b', 'b', 'b', True, 2),
+        ('c', 'c', 'c', False, 3)
+    ]
+
+
+def test_multi_choice_choice_tuples_empty_initial():
+    class MyForm(Form):
+        foo = Field.multi_choice(
+            choices=list('abc'),
+            initial=[],
+        )
+
+    assert MyForm().bind().fields.foo.choice_tuples == [
+        ('a', 'a', 'a', False, 1),
+        ('b', 'b', 'b', False, 2),
+        ('c', 'c', 'c', False, 3)
+    ]
+
+
 def test_form_h_tag():
     assert '<h1>$$$</h1>' in Form(title='$$$').bind(request=req('get')).__html__()
     assert '<b>$$$</b>' in Form(title='$$$', h_tag__tag='b').bind(request=req('get')).__html__()


### PR DESCRIPTION
On multiselect choice (and choice_queryset) the choice_to_option implementation returns the value [] (and not True/False) as third in the choice_to_option tuple. For code using javascript idea "truthiness" to select what to render this leads to a lot of misstakenly rendered options... This should always be True or False

Also, there is no need to have different choice_to_option any more when in the multi-case, so with a little cleanup any choice dericative can be done multiple by adding `is_list=True` now.