### PR TITLE
Fix the bug introduced in #112 by giving the form filter button a distinct class name.

### DIFF
--- a/iommi/query.py
+++ b/iommi/query.py
@@ -642,6 +642,7 @@ class Query(Part):
             _fields_dict=declared_fields,
             attrs__method='get',
             actions__submit__display_name=gettext('Filter'),
+            actions__submit__attrs__class__iommi_submit_filter_button=True,
         )
         declared_members(self).form = self.form
 

--- a/iommi/templates/iommi/query/ajax_enhance.html
+++ b/iommi/templates/iommi/query/ajax_enhance.html
@@ -170,7 +170,7 @@ function enhance(form) {
         s.addEventListener('change', onChange);
      });
 
-    form.querySelector('.links button').remove();
+    form.querySelector('.iommi_submit_filter_button').remove();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
That way we don't rely on class names that are determined by the active style.