### PR TITLE
Start to uncouple form's and their fields

### DIFF
--- a/iommi/form.py
+++ b/iommi/form.py
@@ -612,7 +612,7 @@ class Field(Part):
 
     @property
     def form(self):
-        return self.iommi_parent().iommi_parent()
+        return self.iommi_parent().iommi_evaluate_parameters()['form']
 
     # noinspection PyUnusedLocal
     @staticmethod
@@ -665,7 +665,7 @@ class Field(Part):
         self.form._valid = False
 
     def on_bind(self) -> None:
-        form = self.iommi_parent().iommi_parent()
+        form = self.form
         if self.attr is MISSING:
             self.attr = self._name
         if self.display_name is MISSING:
@@ -788,7 +788,7 @@ class Field(Part):
         return value
 
     def _read_initial(self):
-        form = self.iommi_parent().iommi_parent()
+        form = self.form
         if self.initial is MISSING and self.include and form.instance is not None:
             if self.attr:
                 initial = self.read_from_instance(self, form.instance)
@@ -805,7 +805,7 @@ class Field(Part):
             self.raw_data_list = evaluate_strict(self.raw_data_list, **self.iommi_evaluate_parameters())
             return
 
-        form = self.iommi_parent().iommi_parent()
+        form = self.form
 
         if self.is_list:
             if self.raw_data_list is not None:
@@ -849,11 +849,11 @@ class Field(Part):
 
         if self.is_list:
             return [
-                self.choice_to_option(form=self.iommi_parent(), field=self, choice=v)
+                self.choice_to_option(form=self.form, field=self, choice=v)
                 for v in self.value
             ]
         else:
-            return [self.choice_to_option(form=self.iommi_parent(), field=self, choice=self.value)]
+            return [self.choice_to_option(form=self.form, field=self, choice=self.value)]
 
     @property
     def choice_tuples(self):


### PR DESCRIPTION
This feature in itself is pretty trivial.  It does two things.  Change the implementation of Field.form to the implementation @jlubcke  suggested in discord.  And also it fixed a bunch of existing places inside Field to actually use Field.form in the first place.

The testcases pass and form/all_fields/ of the examples works.

Note I do not yet claim that we can actually start nesting fields inside other elements and everything will work.  I just wanted to prepare the land so to speak...
