### PR TITLE
Removing a members namespace from its parent (aka removing all its children).

### DIFF
--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2018,7 +2018,13 @@ def test_help_text_for_boolean_tristate():
     assert '$$$$' in str(form)
 
 
-def test_form_actions_exclude():
+def test_form_actions_exclude_baseline():
+    """This just shows that normally forms contain one default action."""
+    form = Form().bind(request=req('get'))
+    assert list(keys(form.actions)) == ["submit"]
+
+
+def test_form_actions_exclude_simple():
     form = Form(actions=None).bind(request=req('get'))
     assert form.actions == {}
 
@@ -2036,7 +2042,8 @@ def test_form_actions_exclude_later_should_work():
         class Meta:
             actions__magic__display_name = "A magic button"
 
-    form = MyForm(actions=None).bind(request=req('get'))
+    form = MyForm(actions=None)
+    form = form.bind(request=req('get'))
     assert form.actions == {}
 
 

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2018,6 +2018,19 @@ def test_help_text_for_boolean_tristate():
     assert '$$$$' in str(form)
 
 
+def test_form_with_excluded_actions_none():
+    form = Form(actions=None).bind(request=req('get'))
+    assert form.actions == {}
+
+
+def test_form_with_excluded_actions_meta_none():
+    class MyForm(Form):
+        class Meta:
+            actions = None
+    form = MyForm(actions__submit__post_handler=lambda form, **_: None).bind(request=req('get'))
+    assert form.actions == {}
+
+
 @pytest.mark.django_db
 def test_all_field_shortcuts():
     class MyFancyField(Field):

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2018,16 +2018,25 @@ def test_help_text_for_boolean_tristate():
     assert '$$$$' in str(form)
 
 
-def test_form_with_excluded_actions_none():
+def test_form_actions_exclude():
     form = Form(actions=None).bind(request=req('get'))
     assert form.actions == {}
 
 
-def test_form_with_excluded_actions_meta_none():
+def test_form_actions_exclude_in_meta_should_not_exclude():
     class MyForm(Form):
         class Meta:
             actions = None
     form = MyForm(actions__submit__post_handler=lambda form, **_: None).bind(request=req('get'))
+    assert len(form.actions) == 1
+
+
+def test_form_actions_exclude_later_should_work():
+    class MyForm(Form):
+        class Meta:
+            actions__magic__display_name = "A magic button"
+
+    form = MyForm(actions=None).bind(request=req('get'))
     assert form.actions == {}
 
 

--- a/iommi/member.py
+++ b/iommi/member.py
@@ -134,10 +134,15 @@ def bind_members(parent: Traversable, *, name: str, cls=Members, unknown_types_f
     )
     assert parent._is_bound
     m = m.bind(parent=parent)
-    setattr(parent._bound_members, name, m)
-    setattr(parent, name, m._bound_members)
-    if not lazy:
-        _force_bind_all(m._bound_members)
+    if m is None:
+        d = {}
+        setattr(parent._bound_members, name, d)
+        setattr(parent, name, d)
+    else:
+        setattr(parent._bound_members, name, m)
+        setattr(parent, name, m._bound_members)
+        if not lazy:
+            _force_bind_all(m._bound_members)
 
 
 class ForbiddenNamesException(Exception):


### PR DESCRIPTION
This adds the ability to clear a members Namespace by giving the config <members name>=None.  This results in the corresponding dictionary to be the empty dictionary.

Example use-case:

```python
my_form_without_buttons=Form(actions=None)
```

Note the branch is slightly misnamed.  I originally wanted to support 

```python
my_form_without_buttons=Form(actions__include=False)
```

But that is tricky because at the moment members assume that all the names are available for the client.  In conversation with @jlubcke we determined that we want to keep it like that.  And thereforeo `actions__include=False` will not be supported. 