### PR TITLE
Styling on root

### DIFF
--- a/iommi/debug.py
+++ b/iommi/debug.py
@@ -41,7 +41,7 @@ def dunder_path__format(row, **_):
 
 
 def endpoint__debug_tree(endpoint, **_):
-    root = endpoint.iommi_parent().iommi_parent()
+    root = endpoint.iommi_root()
     assert root._is_bound
 
     def rows(node, name='', path=None):
@@ -64,16 +64,7 @@ def endpoint__debug_tree(endpoint, **_):
                 member_type = type(list(values(declared_members(node)))[0]).__name__
             type_name = f'Members[{member_type}]'
 
-        yield Struct(
-            name=name,
-            obj=node,
-            type=type_name,
-            base_type=base_type_name,
-            path=p,
-            dunder_path='__'.join(path),
-            included=is_bound
-        )
-
+        children = []
         if isinstance(node, dict):
             children = list(node.items())
         elif isinstance(node, Traversable):
@@ -84,8 +75,19 @@ def endpoint__debug_tree(endpoint, **_):
                 )
                 for k, v in items(declared_members(node))
             ]
-        else:
+
+        if (isinstance(node, Members) or isinstance(node, dict)) and not children:
             return
+
+        yield Struct(
+            name=name,
+            obj=node,
+            type=type_name,
+            base_type=base_type_name,
+            path=p,
+            dunder_path='__'.join(path),
+            included=is_bound
+        )
 
         for k, v in children:
             yield from rows(v, name=k, path=path + [k])

--- a/iommi/debug__tests.py
+++ b/iommi/debug__tests.py
@@ -49,20 +49,13 @@ def test_debug_tree(settings):
     expected = """, , MyPage, True
 endpoints, None, Members[Endpoint], True
 endpoints__debug_tree, debug_tree, Endpoint, True
-assets, None, Members, True
 parts, None, Members[Part], True
 parts__bar, bar, Fragment, True
-parts__bar__endpoints, None, Members, True
-parts__bar__assets, None, Members, True
 parts__bar__children, None, Members[str], True
 parts__bar__children__text, None, str, False
 parts__nested, nested, NestedPage, True
-parts__nested__endpoints, None, Members, True
-parts__nested__assets, None, Members, True
 parts__nested__parts, None, Members[Part], True
 parts__nested__parts__foo, foo, Fragment, True
-parts__nested__parts__foo__endpoints, None, Members, True
-parts__nested__parts__foo__assets, None, Members, True
 parts__nested__parts__foo__children, None, Members[str], True
 parts__nested__parts__foo__children__text, None, str, False"""
     assert '\n'.join(tree) == expected

--- a/iommi/debug__tests.py
+++ b/iommi/debug__tests.py
@@ -57,8 +57,7 @@ parts__bar__assets, None, Members, True
 parts__bar__children, None, Members[str], True
 parts__bar__children__text, None, str, False
 parts__nested, nested, NestedPage, True
-parts__nested__endpoints, None, Members[Endpoint], True
-parts__nested__endpoints__debug_tree, nested/debug_tree, Endpoint, True
+parts__nested__endpoints, None, Members, True
 parts__nested__assets, None, Members, True
 parts__nested__parts, None, Members[Part], True
 parts__nested__parts__foo, foo, Fragment, True

--- a/iommi/fragment.py
+++ b/iommi/fragment.py
@@ -140,6 +140,7 @@ class Fragment(Part, Tag):
                 children,
                 text=text,
             )
+        self._iommi_saved_params['text'] = text
         collect_members(self, name='children', items=children, cls=Fragment, unknown_types_fall_through=True)
 
     def render_text_or_children(self, context):

--- a/iommi/page.py
+++ b/iommi/page.py
@@ -12,9 +12,7 @@ from tri_declarative import (
     with_meta,
 )
 
-from iommi.fragment import Fragment
 from iommi._web_compat import (
-    Template,
     format_html,
     template_types,
 )
@@ -23,10 +21,8 @@ from iommi.base import (
     items,
     values,
 )
-from iommi.debug import (
-    endpoint__debug_tree,
-    iommi_debug_on,
-)
+from iommi.evaluate import evaluate_strict_container
+from iommi.fragment import Fragment
 from iommi.member import (
     bind_members,
     collect_members,
@@ -36,12 +32,11 @@ from iommi.part import (
     Part,
     PartType,
 )
+from iommi.reinvokable import reinvokable
 from iommi.traversable import (
     EvaluatedRefinable,
     Traversable,
 )
-from iommi.reinvokable import reinvokable
-from iommi.evaluate import evaluate_strict_container
 
 
 @with_meta
@@ -67,10 +62,6 @@ class Page(Part):
     @reinvokable
     @dispatch(
         parts=EMPTY,
-        endpoints__debug_tree=Namespace(
-            include=lambda endpoint, **_: iommi_debug_on(),
-            func=endpoint__debug_tree,
-        ),
         context=EMPTY,
     )
     def __init__(

--- a/iommi/part.py
+++ b/iommi/part.py
@@ -24,7 +24,10 @@ from iommi.base import (
     items,
     MISSING,
 )
-from iommi.debug import iommi_debug_on
+from iommi.debug import (
+    endpoint__debug_tree,
+    iommi_debug_on,
+)
 from iommi.endpoint import (
     DISPATCH_PATH_SEPARATOR,
     Endpoint,

--- a/iommi/style.py
+++ b/iommi/style.py
@@ -14,6 +14,7 @@ from tri_declarative import (
     getattr_path,
     Namespace,
     RefinableObject,
+    setdefaults_path,
 )
 
 from iommi.base import (
@@ -76,7 +77,7 @@ class Style:
     @dispatch(
         root=EMPTY,
     )
-    def __init__(self, *bases, base_template=None, content_block=None, root=None, **kwargs):
+    def __init__(self, *bases, base_template=None, content_block=None, assets=None, root=None, **kwargs):
         self.name = None
 
         self.base_template = base_template
@@ -92,6 +93,13 @@ class Style:
                 if base.content_block:
                     self.content_block = base.content_block
                     break
+
+        if assets:
+            from iommi.debug import iommi_debug_on
+            if iommi_debug_on():
+                print("Warning: The preferred way to add top level assets config to a Style is via the root argument. "
+                      "I.e. assets__* becomes root__assets__*")
+            setdefaults_path(root, assets=assets)
 
         self.root = {k: v for k, v in items(Namespace(*(base.root for base in bases), root)) if v is not None}
         self.config = Namespace(*[x.config for x in bases], recursive_namespace(kwargs))

--- a/iommi/style.py
+++ b/iommi/style.py
@@ -74,9 +74,9 @@ def recursive_namespace(d):
 
 class Style:
     @dispatch(
-        assets=EMPTY,
+        root=EMPTY,
     )
-    def __init__(self, *bases, base_template=None, content_block=None, assets=None, **kwargs):
+    def __init__(self, *bases, base_template=None, content_block=None, root=None, **kwargs):
         self.name = None
 
         self.base_template = base_template
@@ -93,7 +93,7 @@ class Style:
                     self.content_block = base.content_block
                     break
 
-        self.assets = {k: v for k, v in Namespace(*(base.assets for base in bases), assets).items() if v is not None}
+        self.root = {k: v for k, v in items(Namespace(*(base.root for base in bases), root)) if v is not None}
         self.config = Namespace(*[x.config for x in bases], recursive_namespace(kwargs))
 
     def component(self, obj, is_root=False):
@@ -104,9 +104,6 @@ class Style:
         """
         result = Namespace()
 
-        if self.assets and is_root:
-            result.assets = self.assets
-
         # TODO: is this wrong? Should it take classes first, then loop through shortcuts?
         for class_name in class_names_for(type(obj)):
             if class_name in self.config:
@@ -116,6 +113,10 @@ class Style:
 
                 for shortcut_name in reversed(getattr(obj, '__tri_declarative_shortcut_stack', [])):
                     result = Namespace(result, shortcuts_config.get(shortcut_name, {}))
+
+        if is_root:
+            result = Namespace(result, self.root)
+
         return result
 
 

--- a/iommi/style__tests.py
+++ b/iommi/style__tests.py
@@ -287,7 +287,7 @@ def test_set_class_on_actions_container():
 def test_assets_render_from_style():
     register_style('my_style', Style(
         test,
-        assets__an_asset=Asset.css(attrs__href='http://foo.bar/baz'),
+        root__assets__an_asset=Asset.css(attrs__href='http://foo.bar/baz'),
     ))
 
     class MyPage(Page):
@@ -313,7 +313,7 @@ def test_assets_render_from_style():
 def test_assets_render_any_fragment_from_style():
     register_style('my_style', Style(
         test,
-        assets__an_asset=Fragment('This is a fragment!'),
+        root__assets__an_asset=Fragment('This is a fragment!'),
     ))
 
     class MyPage(Page):

--- a/iommi/style__tests.py
+++ b/iommi/style__tests.py
@@ -290,9 +290,29 @@ def test_assets_render_from_style():
         root__assets__an_asset=Asset.css(attrs__href='http://foo.bar/baz'),
     ))
 
-    class MyPage(Page):
-        class Meta:
-            iommi_style = 'my_style'
+    expected = prettify('''
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title/>
+                <link href='http://foo.bar/baz' rel="stylesheet"/>
+            </head>
+            <body/>
+        </html>
+    ''')
+    actual = prettify(
+        Page(iommi_style='my_style').bind(request=req('get')).render_to_response().content
+    )
+    assert actual == expected
+
+    unregister_style('my_style')
+
+
+def test_deprecated_assets_style():
+    register_style('my_style', Style(
+        test,
+        assets__an_asset=Asset.css(attrs__href='http://foo.bar/baz'),
+    ))
 
     expected = prettify('''
         <!DOCTYPE html>
@@ -304,7 +324,9 @@ def test_assets_render_from_style():
             <body/>
         </html>
     ''')
-    actual = prettify(MyPage().bind(request=req('get')).render_to_response().content)
+    actual = prettify(
+        Page(iommi_style='my_style').bind(request=req('get')).render_to_response().content
+    )
     assert actual == expected
 
     unregister_style('my_style')

--- a/iommi/style_base.py
+++ b/iommi/style_base.py
@@ -1,3 +1,7 @@
+from iommi.debug import (
+    endpoint__debug_tree,
+    iommi_debug_on,
+)
 from iommi.style import Style
 from iommi.asset import Asset
 
@@ -15,22 +19,28 @@ select2_assets = dict(
 base = Style(
     base_template='iommi/base.html',
     content_block='content',
-    assets=dict(
-        jquery=Asset.js(
-            attrs=dict(
-                src='https://code.jquery.com/jquery-3.4.1.js',
-                integrity='sha256-WpOohJOqMqqyKL9FccASB9O0KwACQJpFTUBLTYOVvVU=',
-                crossorigin='anonymous',
-            ),
-            after=-1,
+    root=dict(
+        endpoints__debug_tree=dict(
+            include=lambda endpoint, **_: iommi_debug_on(),
+            func=endpoint__debug_tree,
         ),
-        axios=Asset.js(
-            attrs=dict(
-                src='https://cdn.jsdelivr.net/npm/axios@0.21.0/dist/axios.min.js',
-                integrity='sha256-OPn1YfcEh9W2pwF1iSS+yDk099tYj+plSrCS6Esa9NA=',
-                crossorigin='anonymous',
+        assets=dict(
+            jquery=Asset.js(
+                attrs=dict(
+                    src='https://code.jquery.com/jquery-3.4.1.js',
+                    integrity='sha256-WpOohJOqMqqyKL9FccASB9O0KwACQJpFTUBLTYOVvVU=',
+                    crossorigin='anonymous',
+                ),
+                after=-1,
             ),
-            after=-1,
+            axios=Asset.js(
+                attrs=dict(
+                    src='https://cdn.jsdelivr.net/npm/axios@0.21.0/dist/axios.min.js',
+                    integrity='sha256-OPn1YfcEh9W2pwF1iSS+yDk099tYj+plSrCS6Esa9NA=',
+                    crossorigin='anonymous',
+                ),
+                after=-1,
+            ),
         ),
     ),
     Form=dict(

--- a/iommi/style_bootstrap.py
+++ b/iommi/style_bootstrap.py
@@ -7,7 +7,7 @@ from iommi.asset import Asset
 
 bootstrap_base = Style(
     base,
-    assets=dict(
+    root__assets=dict(
         css=Asset.css(
             attrs=dict(
                 href='https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css',

--- a/iommi/style_bulma.py
+++ b/iommi/style_bulma.py
@@ -25,7 +25,7 @@ navbar_burger_click_js = Fragment(mark_safe("""\
 
 bulma_base = Style(
     base,
-    assets=dict(
+    root__assets=dict(
         css=Asset.css(
             attrs__href='https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css',
         ),

--- a/iommi/style_django_admin.py
+++ b/iommi/style_django_admin.py
@@ -8,7 +8,7 @@ from iommi.style_base import base
 django_admin_base = Style(
     base,
     font_awesome_4,
-    assets=dict(
+    root__assets=dict(
         css_base=html.link(attrs=dict(rel="stylesheet", type="text/css", href="/static/admin/css/base.css")),
         css_login=html.link(attrs=dict(rel="stylesheet", type="text/css", href="/static/admin/css/login.css")),
         css_forms=html.link(attrs=dict(rel="stylesheet", type="text/css", href="/static/admin/css/forms.css")),

--- a/iommi/style_font_awesome_4.py
+++ b/iommi/style_font_awesome_4.py
@@ -3,7 +3,7 @@ from iommi.style import Style
 from iommi.fragment import html
 
 font_awesome_4 = Style(
-    assets__icons=html.link(
+    root__assets__icons=html.link(
         attrs__rel="stylesheet",
         attrs__href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css",
     ),

--- a/iommi/style_foundation.py
+++ b/iommi/style_foundation.py
@@ -8,7 +8,7 @@ from iommi.asset import Asset
 foundation_base = Style(
     base,
     font_awesome_4,
-    assets=dict(
+    root__assets=dict(
         css=Asset.css(
             attrs=dict(
                 href='https://cdn.jsdelivr.net/npm/foundation-sites@6.6.3/dist/css/foundation.min.css',

--- a/iommi/style_semantic_ui.py
+++ b/iommi/style_semantic_ui.py
@@ -7,7 +7,7 @@ from iommi.style_base import base
 
 semantic_ui_base = Style(
     base,
-    assets=dict(
+    root__assets=dict(
         css=html.link(
             attrs=dict(
                 rel='stylesheet',

--- a/iommi/style_test_base.py
+++ b/iommi/style_test_base.py
@@ -5,7 +5,7 @@ from iommi.style_font_awesome_4 import font_awesome_4
 test = Style(
     base,
     font_awesome_4,
-    assets=dict(
+    root__assets=dict(
         jquery=None,
         select2_js=None,
         select2_css=None,

--- a/iommi/style_water.py
+++ b/iommi/style_water.py
@@ -4,7 +4,7 @@ from iommi.asset import Asset
 
 water = Style(
     base,
-    assets__css=Asset.css(
+    root__assets__css=Asset.css(
         attrs=dict(
             href='https://cdn.jsdelivr.net/gh/kognise/water.css@latest/dist/dark.min.css',
         ),


### PR DESCRIPTION
Convert the specifics of the assets styling to be a general add-style-to-root feature

Use new root styling for adding the debug tree endpoint.

Convert top level asset styling to use the new root feature.
