### PR TITLE
Collapse raw data and raw data list

### DIFF
--- a/iommi/form.py
+++ b/iommi/form.py
@@ -776,15 +776,15 @@ class Field(Part):
             self.initial = None
 
     def _read_raw_data(self):
+        # The client might have refined raw_data.  If so evaluate it.
         if self.raw_data is not None:
             self.raw_data = evaluate_strict(self.raw_data, **self.iommi_evaluate_parameters())
             return
 
+        # Otherwise get it from the request
         form = self.form
 
         if self.is_list:
-            if self.raw_data is not None:
-                return
             try:
                 # django and similar
                 # noinspection PyUnresolvedReferences
@@ -799,8 +799,6 @@ class Field(Part):
             if raw_data is not None:
                 self.raw_data = raw_data
         else:
-            if self.raw_data is not None:
-                return
             self.raw_data = form._request_data.get(self.iommi_path)
             if self.raw_data and self.strip_input:
                 self.raw_data = self.raw_data.strip()

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -200,12 +200,12 @@ def test_custom_raw_data():
 def test_custom_raw_data_list():
     # This is useful for example when doing file upload. In that case the data is on request.FILES, not request.POST so we can use this to grab it from there
 
-    def my_form_raw_data_list(**_):
+    def my_form_raw_data(**_):
         return ['this is custom raw data list']
 
     class MyForm(Form):
         foo = Field(
-            raw_data_list=my_form_raw_data_list,
+            raw_data=my_form_raw_data,
             is_list=True,
         )
 
@@ -261,7 +261,7 @@ def test_parse(MyTestForm):
     assert form.fields['admin'].parsed_data is False
     assert form.fields['admin'].value is False
 
-    assert form.fields['manages'].raw_data_list == ['DEF', 'KTH']
+    assert form.fields['manages'].raw_data == ['DEF', 'KTH']
     assert form.fields['manages'].parsed_data == ['DEF', 'KTH']
     assert form.fields['manages'].value == ['DEF', 'KTH']
 
@@ -273,7 +273,7 @@ def test_parse(MyTestForm):
     assert form.fields['a_time'].parsed_data == time(1, 2, 3)
     assert form.fields['a_time'].value == time(1, 2, 3)
 
-    assert form.fields['multi_choice_field'].raw_data_list == ['a', 'b']
+    assert form.fields['multi_choice_field'].raw_data == ['a', 'b']
     assert form.fields['multi_choice_field'].parsed_data == ['a', 'b']
     assert form.fields['multi_choice_field'].value == ['a', 'b']
     assert form.fields['multi_choice_field'].is_list
@@ -352,7 +352,7 @@ def test_parse_errors(MyTestForm):
     assert form.fields['a_time'].parsed_data is None
     assert form.fields['a_time'].value is None
 
-    assert form.fields['multi_choice_field'].raw_data_list == ['q']
+    assert form.fields['multi_choice_field'].raw_data == ['q']
     assert_one_error_and_matches_reg_exp(form.fields['multi_choice_field']._errors, "q not in available choices")
     assert form.fields['multi_choice_field'].parsed_data == ['q']
     assert form.fields['multi_choice_field'].value is None
@@ -1270,7 +1270,7 @@ def shortcut_test(shortcut, raw_and_parsed_data_tuples, normalizing=None, is_lis
             assert not form.get_errors(), 'input: %s' % raw
             f = form.fields.foo
             if f.is_list:
-                assert f.raw_data_list == raw
+                assert f.raw_data == raw
                 assert f.value == initial
                 if initial:
                     assert [type(x) for x in f.value] == [type(x) for x in initial]


### PR DESCRIPTION
Given that always only one of both should be "active" it seemed simpler this way.  