### PR TITLE
Fix reinvoke/reinvoke_new_defaults when shortcut is changed

### DIFF
--- a/iommi/reinvokable.py
+++ b/iommi/reinvokable.py
@@ -45,11 +45,18 @@ def reinvoke(obj: Any, additional_kwargs: Dict[str, Any]) -> Any:
                 else:
                     kwargs[name] = new_param
 
-    additional_kwargs_namespace.pop('call_target', None)
-
     kwargs = Namespace(additional_kwargs_namespace, kwargs)  # Also include those keys not already in the original
 
-    result = type(obj)(**kwargs)
+    call_target = kwargs.pop('call_target', None)
+    if call_target is not None:
+        kwargs['call_target'] = Namespace(
+            call_target,
+            cls=type(obj),
+        )
+    else:
+        kwargs['call_target'] = type(obj)
+
+    result = kwargs()
 
     retain_special_cases(obj, result)
     return result

--- a/iommi/reinvokable__tests.py
+++ b/iommi/reinvokable__tests.py
@@ -160,3 +160,19 @@ def test_reinvoke_extra_shortcut():
 
     assert f.bind().fields.my_field.extra == dict(foo=17, bar=42, buz=4711)
 
+
+def test_reinvoke_change_shortcut():
+    class ReinvokableWithShortcut(MyReinvokable):
+        @classmethod
+        @class_shortcut
+        def shortcut(cls, call_target=None, **kwargs):
+            kwargs['shortcut_was_here'] = True
+            return call_target(**kwargs)
+
+    assert reinvoke(
+        ReinvokableWithShortcut(),
+        dict(
+            call_target__attribute='shortcut',
+            foo='bar',
+        )
+    ).kwargs == dict(foo='bar', shortcut_was_here=True)

--- a/iommi/style.py
+++ b/iommi/style.py
@@ -175,10 +175,17 @@ def reinvoke_new_defaults(obj: Any, additional_kwargs: Dict[str, Any]) -> Any:
                 else:
                     kwargs[name] = saved_param
 
-    additional_kwargs_namespace.pop('call_target', None)
-
     try:
-        result = type(obj)(**kwargs)
+        call_target = kwargs.pop('call_target', None)
+        if call_target is not None:
+            kwargs['call_target'] = Namespace(
+                call_target,
+                cls=type(obj)
+            )
+        else:
+            kwargs['call_target'] = type(obj)
+
+        result = kwargs()
     except TypeError as e:
         raise InvalidStyleConfigurationException(
             f'Object {obj!r} could not be updated with style configuration {flatten(additional_kwargs_namespace)}'

--- a/iommi/style__tests.py
+++ b/iommi/style__tests.py
@@ -275,6 +275,24 @@ def test_reinvokable_new_defaults_recurse():
     assert x.kwargs.foo.kwargs == dict(bar=17, baz=43)
 
 
+def test_reinvoke_new_default_change_shortcut():
+    class ReinvokableWithShortcut(MyReinvokable):
+        @classmethod
+        @class_shortcut
+        def shortcut(cls, call_target=None, **kwargs):
+            kwargs['shortcut_was_here'] = True
+            return call_target(**kwargs)
+
+    assert reinvoke_new_defaults(
+        ReinvokableWithShortcut(),
+        dict(
+            call_target__attribute='shortcut',
+            foo='bar',
+        )
+    ).kwargs == dict(foo='bar', shortcut_was_here=True)
+
+
+
 @pytest.mark.skip('Broken since there is no way to set things on the container of Action')
 def test_set_class_on_actions_container():
     t = Table()

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -2072,7 +2072,7 @@ def test_from_model_with_inheritance():
     )
 
     assert was_called == {
-        'MyField.float': 5,
+        'MyField.float': 6,
         'MyVariable.float': 2,
         'MyColumn.float': 2,
     }


### PR DESCRIPTION
Fix reinvoke/reinvoke_new_defaults to not just drop updated shortcut targets