### PR TITLE
No longer create a submit button by default.

### DIFF
--- a/examples/examples/form_examples.py
+++ b/examples/examples/form_examples.py
@@ -102,9 +102,7 @@ def form_example_3(request):
     class TrackForm(Form):
         artist = Field.choice_queryset(choices=Track.objects.all())
 
-    return TrackForm(
-        actions__submit__include=False,
-    )
+    return TrackForm()
 
 
 @example(gettext(("Create create forms from database models")))
@@ -231,8 +229,7 @@ def form_example_error_messages(request):
         title=gettext('Error messages'),
         auto__model=Artist,
         post_validation=form_error_messages,
-        fields__name__post_validation=field_error_messages,
-        actions__submit__include=False,
+        fields__name__post_validation=field_error_messages
     )
 
 

--- a/iommi/action.py
+++ b/iommi/action.py
@@ -58,11 +58,36 @@ class Action(Fragment):
         # A submit button
         Action.submit(display_name='Do this')
 
-        # The primary submit button on a form, unnecessary
-        # most of the time as a form includes a submit
-        # button by default.
+        # The primary submit button on a form.
         Action.primary()
 
+        # Notice that because forms
+        # with a single primary submit button are so common, iommi assumes
+        # that if you have a action called submit and do NOT explicitly
+        # specify the action that it is a primary action.  This is only
+        # done for the action called submit, inside the Forms actions
+        # Namespace.
+        #
+        # For that reason this works:
+
+        class MyForm(Form):
+            class Meta:
+                @staticmethod
+                def actions__submit__post_handler(form, **_):
+                    if not form.is_valid():
+                        return
+
+                    ...
+
+        # and is roughly equivalent to
+
+        def on_submit(form, **_):
+            if not form.is_valid():
+                return
+
+        class MyForm(Form):
+            class Meta:
+                actions__submit__post_handler = Action.primary(post_handler=on_submit)
     """
 
     group: str = EvaluatedRefinable()

--- a/iommi/form.py
+++ b/iommi/form.py
@@ -1302,7 +1302,7 @@ class Form(Part):
         attrs__action='',
         attrs__method='post',
         attrs__enctype='multipart/form-data',
-        actions__submit__call_target__attribute='primary',
+        actions=EMPTY,
         auto=EMPTY,
         errors=EMPTY,
         h_tag__call_target=Header,
@@ -1333,6 +1333,17 @@ class Form(Part):
                     submit__display_name=gettext('Save') if auto.type == 'edit' else capitalize(gettext(auto.type)),
                 )
 
+        # Submit is special.
+        # We used to have an automatic action submit button.  Now we instead if something is inj
+        # the actions submit space assume you want to define it as a primary button (unless you
+        # explicitely specify differently). That way we get no button if you don't explicitely opt
+        # into it, by either directly defining something inside the submit namespace or using
+        # Form.edit/delete/...
+        if 'submit' in actions:
+            setdefaults_path(
+                actions,
+                submit__call_target__attribute='primary'
+            )
         super(Form, self).__init__(model=model, title=title, **kwargs)
 
         assert isinstance(fields, dict)


### PR DESCRIPTION
But still allow the same concise definitions of the submit button as we did before.  How?  If there is something in actions__submit we by default assume it is a primary button.

As you have to define a post_handler to get anything meaningful anyway this should be silent to real clients.  The hopefully only place where this caused real breakage was some of our tests, as we lazily tend to only specify in the test what is strictly needed to get the test to run.