### PR TITLE
custom raw_data callback should have same semantics as constant value…

### DIFF
--- a/iommi/form.py
+++ b/iommi/form.py
@@ -779,7 +779,8 @@ class Field(Part):
         # The client might have refined raw_data.  If so evaluate it.
         if self.raw_data is not None:
             self.raw_data = evaluate_strict(self.raw_data, **self.iommi_evaluate_parameters())
-            return
+            if self.raw_data is not None:
+                return
 
         # Otherwise get it from the request
         form = self.form

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -229,6 +229,17 @@ def test_custom_raw_data_list():
     assert form.fields.foo.value == ['this is custom raw data list']
 
 
+def test_custom_raw_data_none():
+    def my_form_raw_data(**_):
+        return None
+
+    class MyForm(Form):
+        foo = Field(raw_data=my_form_raw_data)
+
+    form = MyForm().bind(request=req('post', **{'-submit': '', 'foo': 'bar'}))
+    assert form.fields.foo.value == 'bar'
+
+
 def test_custom_parsed_value():
     def my_form_parsed_data(**_):
         return 'this is custom parsed data'
@@ -242,6 +253,21 @@ def test_custom_parsed_value():
 
     form = MyForm().bind(request=req('post', **{'-submit': ''}))
     assert form.fields.foo.value == 'this is custom parsed data'
+
+
+def test_custom_parsed_value_none():
+    def my_form_parsed_data(**_):
+        return None
+
+    class MyForm(Form):
+        foo = Field(parsed_data=my_form_parsed_data)
+
+        class Meta:
+            def actions__submit__post_handler(form, **_):
+                pass
+
+    form = MyForm().bind(request=req('post', **{'-submit': '', 'foo': 'bar'}))
+    assert form.fields.foo.value == 'bar'
 
 
 def test_parse(MyTestForm):


### PR DESCRIPTION
… (and parsed_data callback)