### PR TITLE
Make DebugMenu created on demand to avoid setting of breakpoints

### DIFF
--- a/iommi/debug.py
+++ b/iommi/debug.py
@@ -298,9 +298,8 @@ def iommi_debug_panel(part):
         };
     """
 
-
-    from iommi.menu import DebugMenu
-    return DebugMenu(sub_menu__code__url=source_url).bind(request=part.get_request()).__html__() + mark_safe(f'<script>{script}</script>')
+    from iommi.menu import get_debug_menu
+    return get_debug_menu(sub_menu__code__url=source_url).bind(request=part.get_request()).__html__() + mark_safe(f'<script>{script}</script>')
 
 
 def source_url_from_part(part):

--- a/iommi/menu.py
+++ b/iommi/menu.py
@@ -278,15 +278,18 @@ class Menu(MenuBase):
             current._active = True
 
 
-class DebugMenu(Menu):
-    code = MenuItem(tag='li')
-    tree = MenuItem(url='?/debug_tree', tag='li')
-    pick = MenuItem(url='#', attrs__onclick='window.iommi_start_pick()', tag='li')
-    edit = MenuItem(
-        display_name=lambda request, **_: 'Edit' if request.GET.get('_iommi_live_edit') in (None, 'row') else 'Edit vertical',
-        url=lambda request, **_: '?_iommi_live_edit' if request.GET.get('_iommi_live_edit') in (None, 'row') else '?_iommi_live_edit=row',
-        tag='li',
-        include=lambda **_: 'iommi.live_edit.Middleware' in settings.MIDDLEWARE,
-    )
-    profile = MenuItem(url='?_iommi_prof', tag='li', include=lambda **_: 'iommi.profiling.Middleware' in settings.MIDDLEWARE)
-    sql_trace = MenuItem(display_name='SQL trace', url='?_iommi_sql_trace', tag='li', include=lambda **_: 'iommi.sql_trace.Middleware' in settings.MIDDLEWARE)
+def get_debug_menu(**kwargs):
+    class DebugMenu(Menu):
+        code = MenuItem(tag='li')
+        tree = MenuItem(url='?/debug_tree', tag='li')
+        pick = MenuItem(url='#', attrs__onclick='window.iommi_start_pick()', tag='li')
+        edit = MenuItem(
+            display_name=lambda request, **_: 'Edit' if request.GET.get('_iommi_live_edit') in (None, 'row') else 'Edit vertical',
+            url=lambda request, **_: '?_iommi_live_edit' if request.GET.get('_iommi_live_edit') in (None, 'row') else '?_iommi_live_edit=row',
+            tag='li',
+            include=lambda **_: 'iommi.live_edit.Middleware' in settings.MIDDLEWARE,
+        )
+        profile = MenuItem(url='?_iommi_prof', tag='li', include=lambda **_: 'iommi.profiling.Middleware' in settings.MIDDLEWARE)
+        sql_trace = MenuItem(display_name='SQL trace', url='?_iommi_sql_trace', tag='li', include=lambda **_: 'iommi.sql_trace.Middleware' in settings.MIDDLEWARE)
+
+    return DebugMenu(**kwargs)

--- a/iommi/menu__tests.py
+++ b/iommi/menu__tests.py
@@ -7,7 +7,7 @@ from iommi import (
     MenuItem,
 )
 from iommi._web_compat import Template
-from iommi.menu import DebugMenu
+from iommi.menu import get_debug_menu
 from tests.helpers import req
 
 
@@ -69,7 +69,7 @@ def test_submenu():
 
 
 def test_debug_menu():
-    assert DebugMenu().bind(request=req('get')).__html__() == '<nav style="background: white; border: 1px solid black; bottom: -1px; position: fixed; right: -1px; z-index: 100"><ul style="list-style: none"><li><a class="link" href="/code/">Code</a></li><li><a class="link" href="?/debug_tree">Tree</a></li><li onclick="window.iommi_start_pick()"><a class="link" href="#">Pick</a></li><li><a class="link" href="?_iommi_live_edit">Edit</a></li><li><a class="link" href="?_iommi_prof">Profile</a></li><li><a class="link" href="?_iommi_sql_trace">SQL trace</a></li></ul></nav>'
+    assert get_debug_menu().bind(request=req('get')).__html__() == '<nav style="background: white; border: 1px solid black; bottom: -1px; position: fixed; right: -1px; z-index: 100"><ul style="list-style: none"><li><a class="link" href="/code/">Code</a></li><li><a class="link" href="?/debug_tree">Tree</a></li><li onclick="window.iommi_start_pick()"><a class="link" href="#">Pick</a></li><li><a class="link" href="?_iommi_live_edit">Edit</a></li><li><a class="link" href="?_iommi_prof">Profile</a></li><li><a class="link" href="?_iommi_sql_trace">SQL trace</a></li></ul></nav>'
 
 
 def test_template():

--- a/iommi/style.py
+++ b/iommi/style.py
@@ -233,7 +233,7 @@ def validate_styles(*, additional_classes: List[Type] = None, default_classes=No
         from iommi.table import Paginator
         from iommi.menu import (
             MenuBase,
-            DebugMenu,
+            get_debug_menu,
         )
         from iommi.error import Errors
         from iommi.action import Actions
@@ -245,7 +245,7 @@ def validate_styles(*, additional_classes: List[Type] = None, default_classes=No
             Action,
             Actions,
             Column,
-            DebugMenu,
+            get_debug_menu().__class__,
             Errors,
             Field,
             Form,


### PR DESCRIPTION
The DebugMenu is the only import level code that triggers the collect_members/bind_members machinery.

Making this only evaluated when needed makes for far fewer unintended breakpoints in the debugger when refactoring the internals.