### PR TITLE
Avoid using search_fields when composing queries from model filter values

### DIFF
--- a/iommi/query.py
+++ b/iommi/query.py
@@ -148,25 +148,12 @@ def value_to_str_for_query(filter, v):
         return {True: '1', False: '0'}.get(v)
     if type(v) in (int, float):
         return str(v)
-    if isinstance(v, Model):
-        model = type(v)
-        search_field = filter.search_fields[0]
-        try:
-            v = getattr_path(v, search_field)
-        except AttributeError:
-            raise NoRegisteredSearchFieldException(
-                f'{model.__name__} has no attribute {search_field}. Please register search fields with register_search_fields or specify search_fields.'
-            )
     return to_string_surrounded_by_quote(v)
 
 
 def build_query_expression(*, filter, value):
     if isinstance(value, Model):
-        try:
-            # We ignore the return value on purpose here. We are after the raise.
-            get_search_fields(model=type(value))
-        except NoRegisteredSearchFieldException:
-            return f'{filter.query_name}.pk={value.pk}'
+        return f'{filter.query_name}.pk={value.pk}'
 
     return f'{filter.query_name}{filter.query_operator_for_field}{value_to_str_for_query(filter, value)}'
 

--- a/iommi/query__tests.py
+++ b/iommi/query__tests.py
@@ -31,15 +31,14 @@ from iommi.form import (
     Field,
     Form,
 )
-from iommi.from_model import NoRegisteredSearchFieldException
 from iommi.query import (
+    build_query_expression,
     choice_queryset_value_to_q,
     Filter,
     FREETEXT_SEARCH_NAME,
     Q_OPERATOR_BY_QUERY_OPERATOR,
     Query,
     QueryException,
-    value_to_str_for_query,
 )
 from iommi.traversable import declared_members
 from tests.helpers import req
@@ -49,7 +48,6 @@ from tests.models import (
     EndPointDispatchModel,
     Foo,
     FromModelWithInheritanceTest,
-    NonStandardName,
     TBar,
     TBaz,
     TFoo,
@@ -682,20 +680,9 @@ def test_filter_repr():
 
 
 @pytest.mark.django_db
-def test_nice_error_message():
-    with pytest.raises(NoRegisteredSearchFieldException) as e:
-        value_to_str_for_query(Filter(search_fields=['custom_name_field']), NonStandardName(non_standard_name='foo'))
-
-    assert (
-        str(e.value)
-        == "NonStandardName has no attribute custom_name_field. Please register search fields with register_search_fields or specify search_fields."
-    )
-
-
-@pytest.mark.django_db
-def test_value_to_str_for_query_dunder_path():
-    bar = Bar.objects.create(foo=Foo.objects.create(foo=1))
-    value_to_str_for_query(Filter(search_fields=['foo__foo']), bar)
+def test_build_query_expression_for_model():
+    foo = Foo.objects.create(foo=17)
+    assert build_query_expression(filter=Filter(query_name='bar'), value=foo) == f'bar.pk={foo.pk}'
 
 
 def test_escape_quote():


### PR DESCRIPTION
Always using the .pk fallback approach always is more stable when the search field values might not be unique