### PR TITLE
query_from_indexes should automatically generate filters for foreign …

### DIFF
--- a/iommi/table.py
+++ b/iommi/table.py
@@ -24,6 +24,7 @@ from typing import (
 from urllib.parse import quote_plus
 
 from django.db.models import (
+    AutoField,
     BooleanField,
     ManyToManyField,
     Model,
@@ -1631,7 +1632,7 @@ class Table(Part, Tag):
                     field__display_name=column.display_name,
                 )
                 # Special case for automatic query config
-                if self.query_from_indexes and column.model_field and getattr(column.model_field, 'db_index', False):
+                if self.query_from_indexes and column.model_field and (getattr(column.model_field, 'db_index', False) or isinstance(column.model_field, AutoField)):
                     filter.include = True
 
                 filters[name] = filter()

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -2500,8 +2500,8 @@ def test_query_from_indexes():
         auto__model=QueryFromIndexesTestModel,
         query_from_indexes=True,
     ).bind(request=req('get'))
-    assert list(t.query.filters.keys()) == ['b', 'c']
-    assert list(t.query.form.fields.keys()) == ['b', 'c']
+    assert list(t.query.filters.keys()) == ['b', 'c', 'd']
+    assert list(t.query.form.fields.keys()) == ['b', 'c', 'd']
 
 
 @pytest.mark.django_db

--- a/tests/models.py
+++ b/tests/models.py
@@ -185,6 +185,7 @@ class QueryFromIndexesTestModel(Model):
     a = IntegerField()
     b = CharField(max_length=1, db_index=True)
     c = FloatField(db_index=True)
+    d = ForeignKey(TFoo, on_delete=CASCADE)
 
     class Meta:
         ordering = ('pk',)


### PR DESCRIPTION
…keys