### PR TITLE
Automatically generating a Query from a model with a foreign key was …

### DIFF
--- a/iommi/form.py
+++ b/iommi/form.py
@@ -1043,7 +1043,7 @@ class Field(Part, Tag):
             if isinstance(choices, QuerySet):
                 kwargs['model'] = choices.model
             elif 'model_field' in kwargs:
-                kwargs['model'] = kwargs['model_field'].remote_field.model
+                pass
             else:
                 assert (
                     False

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -2923,3 +2923,8 @@ def test_nested_form_validation_error_propagates_to_parent():
     assert not f.is_valid()
     assert f.nested_forms.inner_form.get_errors() == {'fields': {'inner_field': {'nope'}}}
     assert f.get_errors() == {}
+
+
+def test_filter_model_mixup():
+    f = Form(auto__model=TBar).bind(request=req('get'))
+    assert f.fields.foo.model == TFoo

--- a/iommi/query.py
+++ b/iommi/query.py
@@ -260,6 +260,9 @@ class Filter(Part):
         :param field__include: set to `True` to display a GUI element for this filter in the basic style interface.
         :param field__call_target: the factory to create a `Field` for the basic GUI, for example `Field.choice`. Default: `Field`
         """
+        model_field = kwargs.get('model_field')
+        if model_field and model_field.remote_field:
+            kwargs['model'] = model_field.remote_field.model
 
         super(Filter, self).__init__(**kwargs)
 
@@ -518,7 +521,6 @@ class Filter(Part):
             choices=model_field.remote_field.model.objects.all(),
             extra__django_related_field=True,
         )
-        kwargs['model'] = model_field.remote_field.model
         return call_target(model_field=model_field, **kwargs)
 
 

--- a/iommi/query__tests.py
+++ b/iommi/query__tests.py
@@ -884,3 +884,8 @@ def test_custom_query_name(MyTestQuery):
     query = MyTestQuery(filters__foo_name__query_name='bar').bind(request=None)
     assert repr(query.parse_query_string('bar=7')) == repr(Q(**{'foo__iexact': '7'}))
     assert repr(query.parse_query_string('bar.pk=7')) == repr(Q(**{'foo__pk': 7}))
+
+
+def test_filter_model_mixup():
+    q = Query(auto__model=TBar).bind(request=req('get'))
+    assert q.filters.foo.model == TFoo

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -3467,3 +3467,8 @@ def test_table_foreign_key_column_name():
         auto__include=['foo'],
     ).bind(request=req('get'))
     assert t.columns.foo.display_name == 'Foo'
+
+
+def test_filter_model_mixup():
+    t = Table(auto__model=TBar).bind(request=req('get'))
+    assert t.columns.foo.model == TFoo


### PR DESCRIPTION
…broken in cases where the name field wasn't the same as name field of the parent model