### PR TITLE
Add code tags to examples in query help

### DIFF
--- a/iommi/templates/iommi/query/advanced.html
+++ b/iommi/templates/iommi/query/advanced.html
@@ -20,7 +20,7 @@
             </div>
             <div class="iommi_query_available_query_commands">
                 <h3>{% blocktrans %}Queries{% endblocktrans %}</h3>
-                <ul>
+                <ul class="small">
                     <li>{% blocktrans %}Search for an exact value: <code>field_name=value</code>{% endblocktrans %}</li>
                     <li>{% blocktrans %}Search for an exact value containing space: <code>field_name="value with space"</code>{% endblocktrans %}</li>
                     <li>{% blocktrans %}Containing a text: <code>field_name:val</code>{% endblocktrans %}</li>

--- a/iommi/templates/iommi/query/advanced.html
+++ b/iommi/templates/iommi/query/advanced.html
@@ -14,7 +14,7 @@
                 <h3>{% blocktrans %}Available fields{% endblocktrans %}</h3>
                 <ul>
                     {% for name in query.filters %}
-                        <li>{{ name }}</li>
+                        <li><code>{{ name }}</code></li>
                     {% endfor %}
                 </ul>
             </div>

--- a/iommi/templates/iommi/query/advanced.html
+++ b/iommi/templates/iommi/query/advanced.html
@@ -21,13 +21,13 @@
             <div class="iommi_query_available_query_commands">
                 <h3>{% blocktrans %}Queries{% endblocktrans %}</h3>
                 <ul>
-                    <li>{% blocktrans %}Search for an exact value: field_name=value{% endblocktrans %}</li>
-                    <li>{% blocktrans %}Search for an exact value containing space: field_name="value with space"{% endblocktrans %}</li>
-                    <li>{% blocktrans %}Containing a text: field_name:val{% endblocktrans %}</li>
-                    <li>{% blocktrans %}Exclude a value: field_name!=value{% endblocktrans %}</li>
-                    <li>{% blocktrans %}You can also use &lt;, &gt;, &lt;= and &gt;= to find ranges of values: field_name&lt;10{% endblocktrans %}</li>
-                    <li>{% blocktrans %}To search for dates, use ISO8601 format: field_name>1969-07-20{% endblocktrans %}</li>
-                    <li>{% blocktrans %}You can filter for relative dates: field_name < "10 days ago". Supported fields are days, months, years, quarters and weekdays. They can be negative and abbreviated from "10 days ago" to "-10d".{% endblocktrans %}</li>
+                    <li>{% blocktrans %}Search for an exact value: <code>field_name=value</code>{% endblocktrans %}</li>
+                    <li>{% blocktrans %}Search for an exact value containing space: <code>field_name="value with space"</code>{% endblocktrans %}</li>
+                    <li>{% blocktrans %}Containing a text: <code>field_name:val</code>{% endblocktrans %}</li>
+                    <li>{% blocktrans %}Exclude a value: <code>field_name!=value</code>{% endblocktrans %}</li>
+                    <li>{% blocktrans %}You can also use <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code> and <code>&gt;=</code> to find ranges of values: <code>field_name&lt;10</code>{% endblocktrans %}</li>
+                    <li>{% blocktrans %}To search for dates, use ISO8601 format: <code>field_name>1969-07-20</code>{% endblocktrans %}</li>
+                    <li>{% blocktrans %}You can filter for relative dates: <code>field_name < "10 days ago"</code>. Supported fields are <code>days</code>, <code>months</code>, <code>years</code>, <code>quarters</code> and <code>weekdays</code>. They can be negative and abbreviated from <code>"10 days ago"</code> to <code>"-10d"</code>.{% endblocktrans %}</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Right now, the help text is a bit annoying to look at as the examples of code to paste don't really pop out.

**I have not tested this**, but the included bootstrap should automatically format these into styled inline code blocks which should enforce a slightly different element background, text colour, and change the font to something monospaced.