### PR TITLE
Major bug: tables based on querysets would implicitly use the django …

### DIFF
--- a/iommi/table.py
+++ b/iommi/table.py
@@ -1782,6 +1782,11 @@ class Table(Part, Tag):
 
         evaluate_member(self, 'model', strict=False, **self.iommi_evaluate_parameters())
         evaluate_member(self, 'initial_rows', **self.iommi_evaluate_parameters())
+
+        if isinstance(self.initial_rows, QuerySet):
+            # Copy the QuerySet so we don't get the original QuerySets result cache
+            self.initial_rows = self.initial_rows.all()
+
         self._prepare_sorting()
 
         if not self.sortable:

--- a/iommi/table__tests.py
+++ b/iommi/table__tests.py
@@ -3461,6 +3461,17 @@ def test_lazy_rows(settings):
 
 
 @pytest.mark.django_db
+def test_rows_should_not_cache():
+    q = TBar.objects.all()
+    assert q._result_cache is None, "Cache should be empty"
+    Table(
+        model=TBar,
+        rows=lambda **_: q,
+    ).bind(request=req('get')).render_to_response()
+    assert q._result_cache is None, "Cache should be empty"
+
+
+@pytest.mark.django_db
 def test_auto_model_for_textchoices():
     class TestTable(Table):
         class Meta:


### PR DESCRIPTION
…result cache. This resulted in the contents of the table not changing until after a process restart