### PR TITLE
Refactor how shortcuts are defined so that they can contain definitio…

### DIFF
--- a/iommi/asset.py
+++ b/iommi/asset.py
@@ -1,6 +1,5 @@
-from tri_declarative import class_shortcut
-
 from iommi.fragment import Fragment
+from iommi.shortcut import with_defaults
 
 
 class Asset(Fragment):
@@ -17,10 +16,10 @@ class Asset(Fragment):
     """
 
     @classmethod
-    @class_shortcut(
+    @with_defaults(
         tag='script',
     )
-    def js(cls, text=None, call_target=None, **kwargs):
+    def js(cls, text=None, **kwargs):
         """
         To use this shortcut, pass `attrs__src='/my_url_to_the.js'`
 
@@ -34,14 +33,14 @@ class Asset(Fragment):
 
             Asset.js('window.foo = bar')
         """
-        return call_target(text, **kwargs)
+        return cls(text, **kwargs)
 
     @classmethod
-    @class_shortcut(
+    @with_defaults(
         tag='link',
         attrs__rel='stylesheet',
     )
-    def css(cls, text=None, call_target=None, **kwargs):
+    def css(cls, text=None, **kwargs):
         """
         To use this shortcut, pass `attrs__href='/my_url_to_the.js'`
 
@@ -57,4 +56,4 @@ class Asset(Fragment):
 
             Asset.css('p { font-size: 18pt; }')
         """
-        return call_target(text, **kwargs)
+        return cls(text, **kwargs)

--- a/iommi/docs.py
+++ b/iommi/docs.py
@@ -5,7 +5,6 @@ from typing import get_type_hints
 
 from tri_declarative import (
     flatten,
-    flatten_items,
     get_declared,
     get_shortcuts_by_name,
     Namespace,
@@ -137,7 +136,7 @@ def _generate_tests_from_class_docs(classes):
         return (' ' * levels * 4) + s.strip()
 
     def get_namespace(c):
-        return Namespace({k: getattr(c.__init__, 'dispatch', {}).get(k) for k, v in items(get_declared(c, 'refinable'))})
+        return Namespace({k: getattr(c.__init__, '__iommi_with_defaults_kwargs', {}).get(k) for k, v in items(get_declared(c, 'refinable'))})
 
     for c in classes:
         from io import StringIO
@@ -302,7 +301,7 @@ request = req('get')
                     w(0, '')
                     w(0, '')
 
-                defaults = shortcut if isinstance(shortcut, dict) else shortcut.dispatch
+                defaults = shortcut if isinstance(shortcut, dict) else getattr(shortcut, '__iommi_with_defaults_kwargs', {})
                 if defaults:
                     defaults = Namespace(defaults)
                     section(3, 'Defaults')

--- a/iommi/docs__tests.py
+++ b/iommi/docs__tests.py
@@ -3,8 +3,6 @@ from typing import Dict
 
 import pytest
 from tri_declarative import (
-    class_shortcut,
-    dispatch,
     Refinable,
     refinable,
     Shortcut,
@@ -16,6 +14,7 @@ from iommi.docs import (
     get_default_classes,
 )
 from iommi.refinable import RefinableObject
+from iommi.shortcut import with_defaults
 
 
 def test_generate_docs(snapshot):
@@ -32,7 +31,7 @@ def test_generate_docs(snapshot):
         some_other_thing = Refinable()
         empty_string_default = Refinable()
 
-        @dispatch(
+        @with_defaults(
             name='foo-name',
             description=lambda foo, bar: 'qwe',
             some_other_thing=some_callable,
@@ -50,29 +49,29 @@ def test_generate_docs(snapshot):
             pass  # pragma: no cover
 
         @classmethod
-        @class_shortcut
+        @with_defaults
         def shortcut1(cls):
             return cls()  # pragma: no cover
 
         @classmethod
-        @class_shortcut(description='fish')
-        def shortcut2(cls, call_target):
+        @with_defaults(description='fish')
+        def shortcut2(cls):
             """shortcut2 docstring"""
-            return call_target()  # pragma: no cover
+            return cls()  # pragma: no cover
 
         @classmethod
         # fmt: off
-        @class_shortcut(
-            description=lambda foo: 'qwe'
+        @with_defaults(
+            description=lambda foo: 'qwe',
         )
         # fmt: on
-        def shortcut3(cls, call_target):
+        def shortcut3(cls):
             """
             shortcut3 docstring
 
             :param call_target: something something call_target
             """
-            return call_target()  # pragma: no cover
+            return cls()  # pragma: no cover
 
     Foo.shortcut4 = Shortcut(
         call_target=Foo,
@@ -106,7 +105,7 @@ def test_generate_docs_description_and_params_in_constructor(snapshot):
 
         name = Refinable()
 
-        @dispatch
+        @with_defaults
         def __init__(self, **kwargs):
             """
             __init__ description
@@ -126,7 +125,7 @@ def test_generate_docs_kill_obscure_mutant(snapshot):
     class Foo(RefinableObject):
         name = Refinable()
 
-        @dispatch(
+        @with_defaults(
             # this is to handle that mutmut mutates strip(',') to strip('XX,XX')
             name=lambda X: X,
         )

--- a/iommi/edit_table.py
+++ b/iommi/edit_table.py
@@ -13,7 +13,6 @@ from django.template import (
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy
 from tri_declarative import (
-    class_shortcut,
     EMPTY,
     getattr_path,
     Namespace,
@@ -43,6 +42,7 @@ from iommi.form import (
 from iommi.fragment import (
     Fragment,
 )
+from iommi.shortcut import with_defaults
 from iommi.table import (
     Cell,
     Cells,
@@ -128,7 +128,7 @@ class EditColumn(Column):
         self.edit = None
 
     @classmethod
-    @class_shortcut(
+    @with_defaults(
         header__template='iommi/table/header.html',
         sortable=False,
         filter__is_valid_filter=lambda **_: (True, ''),
@@ -152,7 +152,7 @@ class EditColumn(Column):
             tag='script',
         )
     )
-    def delete(cls, call_target=None, **kwargs):
+    def delete(cls, **kwargs):
         def cell__value(row, table, cells, column, **_):
             if isinstance(table.rows, QuerySet):
                 row_id = row.pk
@@ -165,7 +165,7 @@ class EditColumn(Column):
             return mark_safe(f'{button.__html__()}<input style="display: none" type="checkbox" name="{path}" />')
 
         setdefaults_path(kwargs, dict(cell__value=cell__value))
-        return call_target(**kwargs)
+        return cls(**kwargs)
 
 
 def edit_table__post_handler(table, request, **_):

--- a/iommi/endpoint.py
+++ b/iommi/endpoint.py
@@ -1,12 +1,10 @@
 from typing import Callable
 
-from tri_declarative import (
-    dispatch,
-    Refinable,
-)
+from tri_declarative import Refinable
 
 from iommi.base import keys
 from iommi.refinable import EvaluatedRefinable
+from iommi.shortcut import with_defaults
 from iommi.traversable import (
     get_long_path_by_path,
     get_path_by_long_path,
@@ -53,7 +51,7 @@ class Endpoint(Traversable):
     func: Callable = Refinable()
     include: bool = EvaluatedRefinable()
 
-    @dispatch(
+    @with_defaults(
         func=None,
         include=True,
     )

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -20,7 +20,6 @@ from django.core.exceptions import FieldError
 from django.http.response import HttpResponseBase
 from django.test import override_settings
 from tri_declarative import (
-    class_shortcut,
     get_members,
     getattr_path,
     is_shortcut,
@@ -80,6 +79,7 @@ from iommi.from_model import (
 from iommi.page import (
     Page,
 )
+from iommi.shortcut import with_defaults
 from tests.compat import RequestFactory
 from tests.helpers import (
     get_attrs,
@@ -1055,8 +1055,8 @@ def test_missing_choices():
     with pytest.raises(AssertionError, match='To use Field.choice, you must pass the choices list'):
         Field.multi_choice().refine_done()
 
-    # with pytest.raises(AssertionError, match='The convenience feature to automatically get the parameter model set only works for QuerySet instances or if you specify model_field'):
-    #     Field.choice_queryset().refine_done()
+    with pytest.raises(AssertionError, match='The convenience feature to automatically get the parameter model set only works for QuerySet instances or if you specify model_field'):
+        Field.choice_queryset().refine_done()
 
 
 @pytest.mark.django_db
@@ -2302,10 +2302,10 @@ def test_from_model_with_inheritance():
 
     class MyField(Field):
         @classmethod
-        @class_shortcut
-        def float(cls, call_target=None, **kwargs):
+        @with_defaults
+        def float(cls, **kwargs):
             was_called['MyField.float'] += 1
-            return call_target(**kwargs)
+            return cls(**kwargs)
 
     class MyForm(Form):
         class Meta:
@@ -2426,9 +2426,9 @@ def test_all_field_shortcuts():
 def test_shortcut_to_subclass():
     class MyField(Field):
         @classmethod
-        @class_shortcut
-        def my_shortcut(cls, call_target=None, **kwargs):
-            return call_target(
+        @with_defaults()
+        def my_shortcut(cls, **kwargs):
+            return cls(
                 **kwargs
             )  # pragma: no cover: we aren't testing that this shortcut is implemented correctly
 
@@ -2436,9 +2436,9 @@ def test_shortcut_to_subclass():
 
     class MyField(Field):
         @classmethod
-        @class_shortcut
-        def choices(cls, call_target=None, **kwargs):
-            return call_target(
+        @with_defaults
+        def choices(cls, **kwargs):
+            return cls(
                 **kwargs
             )  # pragma: no cover: we aren't testing that this shortcut is implemented correctly
 

--- a/iommi/fragment.py
+++ b/iommi/fragment.py
@@ -42,8 +42,10 @@ from iommi.part import (
 # https://html.spec.whatwg.org/multipage/syntax.html#void-elements
 from iommi.refinable import (
     EvaluatedRefinable,
+    Prio,
     RefinableMembers,
 )
+from iommi.shortcut import with_defaults
 
 _void_elements = [
     'area',
@@ -156,15 +158,16 @@ class Fragment(Part, Tag):
     template: Union[str, Template] = EvaluatedRefinable()
     children = RefinableMembers()
 
-    @dispatch(
-        children=EMPTY,
-        attrs__class=EMPTY,
-        attrs__style=EMPTY,
-    )
+    class Meta:
+        children = EMPTY
+        attrs__class = EMPTY
+        attrs__style = EMPTY
+
+    @with_defaults
     def __init__(self, text=None, **kwargs):
-        if text is not None:
-            kwargs['children'].text = text
         super().__init__(_collect_instantiated_at_info=False, **kwargs)
+        if text is not None:
+            self.refine(Prio.constructor, children__text=text)
 
     def on_refine_done(self):
         super().on_refine_done()

--- a/iommi/from_model__tests.py
+++ b/iommi/from_model__tests.py
@@ -7,6 +7,7 @@ from django.db.models import (
     IntegerField,
     Model,
 )
+
 from iommi import (
     Field,
     Form,
@@ -18,12 +19,12 @@ from iommi.from_model import (
     register_search_fields,
     SearchFieldsAlreadyRegisteredException,
 )
+from iommi.shortcut import with_defaults
 from tests.helpers import req
 from tests.models import (
     Foo,
     FormFromModelTest,
 )
-from tri_declarative import class_shortcut
 
 
 def test_get_name_field_for_model_error():
@@ -208,12 +209,11 @@ def test_register_search_fields_pk_special_case():
 def MyField():
     class MyField(Field):
         @classmethod
-        @class_shortcut(
-            call_target__attribute='integer',
+        @with_defaults(
             extra__value='this is my shortcut',
         )
-        def my_integer(cls, call_target=None, **kwargs):
-            return call_target(**kwargs)
+        def my_integer(cls, **kwargs):
+            return cls.integer(**kwargs)
     return MyField
 
 

--- a/iommi/member.py
+++ b/iommi/member.py
@@ -15,7 +15,10 @@ from iommi.base import (
     items,
     keys,
 )
-from iommi.refinable import RefinableMembers
+from iommi.refinable import (
+    Prio,
+    RefinableMembers,
+)
 from iommi.sort_after import sort_after
 from iommi.traversable import (
     Traversable,
@@ -119,7 +122,7 @@ def refine_done_members(
                 member_by_name[key] = item
 
     for k, v in items(Namespace(_unapplied_config)):
-        member_by_name[k] = member_by_name[k].refine(**v)
+        member_by_name[k] = member_by_name[k].refine(Prio.member, **v)
         # noinspection PyProtectedMember
         assert member_by_name[k]._name is not None
 
@@ -128,7 +131,7 @@ def refine_done_members(
             if k in member_by_name:
                 v = Namespace(v)
                 v.pop('call_target', None)
-                member_by_name[k] = member_by_name[k].refine_defaults(**v)
+                member_by_name[k] = member_by_name[k].refine(Prio.member_defaults, **v)
             else:
                 member_by_name[k] = Namespace(
                     v,

--- a/iommi/member__tests.py
+++ b/iommi/member__tests.py
@@ -1,6 +1,5 @@
 import pytest
 from tri_declarative import (
-    class_shortcut,
     dispatch,
     Refinable,
 )
@@ -13,6 +12,7 @@ from iommi import (
     Style,
 )
 from iommi.member import ForbiddenNamesException
+from iommi.shortcut import with_defaults
 from tests.helpers import (
     Basket,
     Fruit,
@@ -236,16 +236,20 @@ def test_precedence_override_shortcut(foo_style):
         foo = html.div('from declaration')
 
         @classmethod
-        @class_shortcut(
+        @with_defaults(
             extra__foo='from shortcut',
             parts__foo=html.div('from shortcut'),
         )
-        def shortcut(cls, call_target, **kwargs):
-            return call_target(**kwargs)
+        def shortcut(cls, **kwargs):
+            return cls(**kwargs)
 
-    my_page = MyPage.shortcut(iommi_style='foo').bind()
+    my_page = MyPage.shortcut().bind()
     assert my_page.extra.foo == 'from shortcut'
     assert str(my_page) == '<div>from shortcut</div>'
+
+    my_page = MyPage.shortcut(iommi_style='foo').bind()
+    assert my_page.extra.foo == 'from style'
+    assert str(my_page) == '<div>from style</div>'
 
     my_page = MyPage.shortcut(
         iommi_style='foo',
@@ -256,7 +260,6 @@ def test_precedence_override_shortcut(foo_style):
     assert str(my_page) == '<div>from constructor call</div>'
 
 
-@pytest.mark.skip(reason='Style should be able to override shortcuts, but that is yet to be done')
 def test_precedence_override_style_with_shortcut(foo_style):
     bar_style = Style(
         foo_style,
@@ -265,17 +268,16 @@ def test_precedence_override_style_with_shortcut(foo_style):
     )
 
     with register_style('bar', bar_style):
-
         class MyPage(Page):
             foo = html.div('from declaration')
 
             @classmethod
-            @class_shortcut(
+            @with_defaults(
                 extra__foo='from shortcut',
                 parts__foo=html.div('from shortcut'),
             )
-            def shortcut(cls, call_target, **kwargs):
-                return call_target(**kwargs)
+            def shortcut(cls, **kwargs):
+                return cls(**kwargs)
 
         my_page = MyPage.shortcut().bind()
         assert my_page.extra.foo == 'from shortcut'

--- a/iommi/part.py
+++ b/iommi/part.py
@@ -41,6 +41,7 @@ from iommi.member import (
     bind_members,
     refine_done_members,
 )
+from iommi.shortcut import with_defaults
 from iommi.style import (
     get_style_object,
 )
@@ -75,8 +76,10 @@ class Part(Traversable):
     # Only the assets used by this part
     assets: Namespace = RefinableMembers()
 
-    @dispatch(
-        extra=EMPTY,
+    class Meta:
+        extra = EMPTY
+
+    @with_defaults(
         include=True,
     )
     def __init__(self, _collect_instantiated_at_info=True, **kwargs):

--- a/iommi/shortcut.py
+++ b/iommi/shortcut.py
@@ -1,0 +1,62 @@
+import functools
+
+from tri_declarative import shortcut
+
+from iommi.refinable import Prio
+
+
+def with_defaults(__target__=None, **decorator_kwargs):
+    def decorator(__target__):
+        @functools.wraps(__target__)
+        @shortcut
+        def wrapper_for_with_defaults(*args, **kwargs):
+            instance = __target__(*args, **kwargs)
+
+            name = __target__.__name__
+            if name == '__init__':
+                args[0].refine(Prio.constructor, **decorator_kwargs)
+            else:
+                instance = instance.refine(
+                    Prio.shortcut,
+                    **decorator_kwargs,
+                )
+
+                shortcut_stack = [name] + getattr(instance, '__tri_declarative_shortcut_stack', [])
+                try:
+                    instance.__tri_declarative_shortcut_stack = shortcut_stack
+                except AttributeError:
+                    pass
+
+            return instance
+        wrapper_for_with_defaults.__iommi_with_defaults_kwargs = decorator_kwargs
+        return wrapper_for_with_defaults
+
+    if __target__ is not None:
+        return decorator(__target__)
+
+    return decorator
+
+
+def superinvoking_classmethod(f):
+    @functools.wraps(f)
+    def wrapper_for_superinvoking_classmethod(cls, **kwargs):
+        def super_classmethod_invoker(*args, **kwargs):
+            parent_classmethod = None
+            for parent_class in list(cls.mro())[1:]:
+                candidate = vars(parent_class).get(f.__name__)
+                if candidate is not None:
+                    if parent_classmethod is None:
+                        parent_classmethod = candidate
+                    if candidate.__func__ == wrapper_for_superinvoking_classmethod:
+                        # Infinite loop avoidance, we found ourselves.
+                        parent_classmethod = None
+
+            if parent_classmethod is None:
+                raise TypeError(f'Unable to find parent class implementation of {cls.__name__}:{f.__name__}')
+
+            undecorated_parent = parent_classmethod.__func__
+            return undecorated_parent(cls, *args, **kwargs)
+
+        return f(cls, super_classmethod=super_classmethod_invoker, **kwargs)
+
+    return wrapper_for_superinvoking_classmethod

--- a/iommi/shortcut__tests.py
+++ b/iommi/shortcut__tests.py
@@ -1,0 +1,318 @@
+import pytest
+from tri_declarative import (
+    dispatch,
+    get_shortcuts_by_name,
+    is_shortcut,
+    Namespace,
+    Refinable,
+    Shortcut,
+    shortcut,
+)
+
+from iommi import (
+    Part,
+    register_style,
+    Style,
+)
+from iommi.refinable import (
+    Prio,
+    RefinableObject,
+)
+from iommi.shortcut import (
+    superinvoking_classmethod,
+    with_defaults,
+)
+
+
+def test_is_shortcut():
+    t = Namespace(x=1)
+    assert not is_shortcut(t)
+
+    s = Shortcut(x=1)
+    assert isinstance(s, Namespace)
+    assert is_shortcut(s)
+
+
+def test_is_shortcut_function():
+    def f():
+        pass
+
+    assert not is_shortcut(f)
+
+    @shortcut
+    def g():
+        pass
+
+    assert is_shortcut(g)
+
+    class Foo:
+        @staticmethod
+        @shortcut
+        def h():
+            pass
+
+        @classmethod
+        @with_defaults
+        def i(cls):
+            pass
+
+    assert is_shortcut(Foo.h)
+    assert is_shortcut(Foo.i)
+
+
+def test_get_shortcuts_by_name():
+    class Foo:
+        a = Shortcut(x=1)
+
+    class Bar(Foo):
+        @staticmethod
+        @shortcut
+        def b(self):
+            pass
+
+        @classmethod
+        @with_defaults()
+        def c(cls):
+            pass
+
+    assert get_shortcuts_by_name(Bar) == dict(a=Bar.a, b=Bar.b, c=Bar.c)
+
+
+def test_shortcut_to_superclass_two_calls_no_decorator():
+    class Foo(RefinableObject):
+        x = Refinable()
+        y = Refinable()
+        z = Refinable()
+
+        @classmethod
+        @with_defaults
+        def buzz(cls, **kwargs):
+            result = cls(**kwargs)
+            return result.refine(Prio.shortcut, z=4711)
+
+        @classmethod
+        @with_defaults
+        def baz(cls, **kwargs):
+            result = cls.buzz(**kwargs)
+            return result.refine(Prio.shortcut, x=17)
+
+    class Bar(Foo):
+        @classmethod
+        @superinvoking_classmethod
+        @with_defaults
+        def baz(cls, super_classmethod, **kwargs):
+            result = super_classmethod(**kwargs)
+            return result.refine(Prio.shortcut, y=42)
+
+    result = Bar.baz()
+    assert result.iommi_namespace == dict(x=17, y=42, z=4711)
+    assert isinstance(result, Bar)
+
+
+def test_shortcut_to_superclass_two_calls2():
+    class Foo(RefinableObject):
+        v = Refinable()
+        w = Refinable()
+        x = Refinable()
+        y = Refinable()
+        z = Refinable()
+
+        @with_defaults(
+            w=123,
+        )
+        def __init__(self, **kwargs):
+            super(Foo, self).__init__(**kwargs)
+
+        @classmethod
+        @with_defaults(
+            z=4711
+        )
+        def buzz(cls, **kwargs):
+            return cls(**kwargs)
+
+        @classmethod
+        @with_defaults(
+            x=17
+        )
+        def baz(cls, **kwargs):
+            return cls.buzz(**kwargs)
+
+    class Bar(Foo):
+        @classmethod
+        @superinvoking_classmethod
+        @with_defaults(
+            y=42
+        )
+        def baz(cls, super_classmethod=None, **kwargs):
+            return super_classmethod(**kwargs)
+
+    result = Bar.baz(v=456)
+    result.refine_done()
+
+    assert result.iommi_namespace == dict(v=456, w=123, x=17, y=42, z=4711)
+    assert isinstance(result, Bar)
+    assert result.iommi_namespace.as_stack() == [
+        ('constructor', {'w': 123}),
+        ('shortcut', {'z': 4711}),
+        ('shortcut', {'x': 17}),
+        ('shortcut', {'y': 42}),
+        ('base', {'v': 456}),
+    ]
+
+
+def test_nested_namespace_overriding_and_calling():
+    @dispatch
+    def f(extra):
+        return extra.foo
+
+    foo = Shortcut(
+        call_target=f,
+        extra__foo='asd',
+    )
+    assert foo(extra__foo='qwe') == 'qwe'
+
+
+def test_retain_shortcut_type():
+    assert isinstance(Shortcut(foo=Shortcut()).foo, Shortcut)
+    assert isinstance(Shortcut(foo=Shortcut(bar=Shortcut())).foo.bar, Shortcut)
+
+    assert Shortcut(foo__bar__q=1, foo=Shortcut(bar=Shortcut())).foo.bar.q == 1
+
+
+def test_shortcut_call_target_attribute():
+    class Foo:
+        @classmethod
+        def foo(cls):
+            return cls
+
+    assert Shortcut(call_target__attribute='foo', call_target__cls=Foo)() is Foo
+    assert isinstance(Shortcut(call_target__cls=Foo)(), Foo)
+
+
+def test_namespace_shortcut_overwrite():
+    assert Namespace(
+        Namespace(
+            x=Shortcut(y__z=1, y__zz=2),
+        ),
+        Namespace(
+            x=Namespace(a__b=3),
+        ),
+    ) == Namespace(
+        x__a__b=3,
+    )
+
+
+def test_namespace_shortcut_overwrite_backward():
+    assert Namespace(
+        Namespace(x=Namespace(y__z=1, y__zz=2)),
+        Namespace(x=Shortcut(a__b=3)),
+    ) == Namespace(
+        x__a__b=3,
+        x__y__z=1,
+        x__y__zz=2,
+    )
+
+
+def test_better_shortcut():
+    class MyPart(Part):
+        @classmethod
+        @with_defaults(
+            extra__thing='shortcut_thing'
+        )
+        def my_shortcut(cls, **kwargs):
+            return cls(**kwargs)
+
+    assert MyPart.my_shortcut().bind().extra.thing == 'shortcut_thing'
+
+    with register_style('my_style', Style(MyPart__shortcuts__my_shortcut__extra__thing='style_thing')):
+        assert MyPart.my_shortcut(iommi_style='my_style').bind().extra.thing == 'style_thing'
+
+
+def test_shortcut_to_superclass():
+    class Foo(RefinableObject):
+        def __init__(self, **kwargs):
+            super(Foo, self).__init__(**kwargs)
+
+        @classmethod
+        @with_defaults(
+            x=17
+        )
+        def baz(cls, **kwargs):
+            return cls(**kwargs)
+
+    class Bar(Foo):
+        @classmethod
+        @superinvoking_classmethod
+        @with_defaults(
+            y=42
+        )
+        def baz(cls, super_classmethod, **kwargs):
+            return super_classmethod(**kwargs)
+
+    result = Bar.baz()
+    assert result.iommi_namespace == dict(x=17, y=42)
+    assert isinstance(result, Bar)
+
+
+def test_superinvoking_twice():
+    class Foo(RefinableObject):
+        @classmethod
+        @with_defaults(
+            x=17,
+        )
+        def foo(cls, **kwargs):
+            return cls(**kwargs)
+
+    class Bar(Foo):
+        @classmethod
+        @superinvoking_classmethod
+        @with_defaults(
+            y=42,
+        )
+        def foo(cls, super_classmethod, **kwargs):
+            return super_classmethod(**kwargs)
+
+    assert Bar.foo().iommi_namespace == dict(x=17, y=42)
+
+    class Baz(Bar):
+        @classmethod
+        @superinvoking_classmethod
+        @with_defaults(
+            z=9,
+        )
+        def foo(cls, super_classmethod, **kwargs):
+            return super_classmethod(**kwargs)
+
+    assert Baz.foo().iommi_namespace == dict(x=17, y=42, z=9)
+
+
+def test_superinvoking_misconfig_no_super_warning():
+    class Foo:
+        pass
+
+    with pytest.raises(TypeError, match='Unable to find parent class implementation of Bar:baz'):
+        class Bar(Foo):
+            @classmethod
+            @superinvoking_classmethod
+            def baz(cls, super_classmethod):
+                super_classmethod()
+        Bar.baz()
+
+
+@pytest.mark.skip  # todo fix?
+def test_superinvoking_misconfig_other_decorator_warning():
+    class Foo:
+        pass
+
+    def other_decorator(f):
+        def wrapper():
+            return f()
+        return wrapper
+
+    with pytest.raises(TypeError):
+        class Bar(Foo):
+            @classmethod
+            @other_decorator
+            @superinvoking_classmethod
+            def baz(cls, super_classmethod):
+                pass

--- a/iommi/style_base.py
+++ b/iommi/style_base.py
@@ -153,13 +153,6 @@ base = Style(
                 template='iommi/form/heading.html',
             ),
         ),
-        tag='div',
-        input__attrs__type='text',
-        input__tag='input',
-        label__tag='label',
-        non_editable_input__attrs__disabled=True,
-        help__attrs__class__helptext=True,
-        help__tag='div',
     ),
     Column=dict(
         shortcuts=dict(

--- a/iommi/traversable.py
+++ b/iommi/traversable.py
@@ -26,6 +26,7 @@ from iommi.refinable import (
     evaluated_refinable,
     EvaluatedRefinable,
     is_evaluated_refinable,
+    Prio,
     RefinableMembers,
     RefinableObject,
 )
@@ -125,7 +126,9 @@ class Traversable(RefinableObject):
 
         style_data = get_style_data_for_object(iommi_style, obj=self, is_root=is_root)
 
-        result = self.refine_defaults(**style_data)
+        result = self.refine(Prio.style, **style_data)
+        del self
+
         result.iommi_style = iommi_style
         return result
 

--- a/iommi/traversable__tests.py
+++ b/iommi/traversable__tests.py
@@ -2,7 +2,6 @@ from typing import Dict
 
 import pytest
 from tri_declarative import (
-    class_shortcut,
     declarative,
     dispatch,
     EMPTY,
@@ -38,6 +37,10 @@ from iommi.refinable import (
     evaluated_refinable,
     EvaluatedRefinable,
     RefinableMembers,
+)
+from iommi.shortcut import (
+    superinvoking_classmethod,
+    with_defaults,
 )
 from iommi.traversable import (
     build_long_path_by_path,
@@ -358,11 +361,11 @@ def test_get_config():
                 super(FruitBase, self).__init__(**kwargs)
 
             @classmethod
-            @class_shortcut(
+            @with_defaults(
                 attrs__class__fruit_shortcut_base=True,
             )
-            def fruit_shortcut(cls, *, call_target=None, **kwargs):
-                return call_target(**kwargs)
+            def fruit_shortcut(cls, **kwargs):
+                return cls(**kwargs)
 
         class Fruit(FruitBase):
             @dispatch(
@@ -372,12 +375,12 @@ def test_get_config():
                 super(Fruit, self).__init__(**kwargs)
 
             @classmethod
-            @class_shortcut(
-                call_target__attribute='fruit_shortcut',
+            @superinvoking_classmethod
+            @with_defaults(
                 attrs__class__fruit_shortcut=True,
             )
-            def fruit_shortcut(cls, *, call_target=None, **kwargs):
-                return call_target(**kwargs)
+            def fruit_shortcut(cls, super_classmethod=None, **kwargs):
+                return super_classmethod(**kwargs)
 
         @declarative(Fruit, 'fruits', add_init_kwargs=False)
         @with_meta


### PR DESCRIPTION
…ns that can be shaddowed by styling

- Refactor RefinableNamespace to be able to controll refinement order

- Steal shortcut tests from tri.declarative

- Refactor and introduce @iommi_class_shortcut

- Port existing shortcuts

- Change default page size to 16