### PR TITLE
Enable usage of 'reverse_lazy' with 'redirect_to'

### DIFF
--- a/iommi/form.py
+++ b/iommi/form.py
@@ -31,6 +31,7 @@ from django.db.models import (
 )
 from django.http.response import HttpResponseBase
 from django.template import Context
+from django.utils.functional import Promise
 from django.utils.translation import gettext
 from iommi.struct import Struct
 
@@ -1240,8 +1241,20 @@ class Field(Part, Tag):
         return cls.multi_choice_queryset(model_field=model_field, **kwargs)
 
 
+def is_django_promise_with_string_proxy(redirect_to):
+    return (
+            isinstance(redirect_to, Promise)
+            and redirect_to._proxy____kw == {}
+            and len(redirect_to._proxy____args) == 1
+            and isinstance(redirect_to._proxy____args[0], str)
+    )
+
 def create_or_edit_object_redirect(is_create, redirect_to, request, redirect, form):
-    assert redirect_to is None or isinstance(redirect_to, str), 'redirect_to must be a str'
+    assert (
+            redirect_to is None
+            or isinstance(redirect_to, str)
+            or is_django_promise_with_string_proxy(redirect_to)
+    ), 'redirect_to must be a str'
     if redirect_to is None:
         if is_create:
             redirect_to = "../"

--- a/iommi/form__tests.py
+++ b/iommi/form__tests.py
@@ -19,6 +19,7 @@ from bs4 import BeautifulSoup
 from django.core.exceptions import FieldError
 from django.http.response import HttpResponseBase
 from django.test import override_settings
+from django.urls import reverse_lazy
 from iommi.struct import (
     merged,
     Struct,
@@ -2739,7 +2740,36 @@ def test_redirect_default_case():
             self.kwargs = kwargs
 
     assert (
-        create_or_edit_object_redirect(**merged(expected, is_create=sentinel1, redirect=lambda **kwargs: FakeHttpResponse(**kwargs))).kwargs
+            create_or_edit_object_redirect(
+                **merged(
+                    expected,
+                    is_create=sentinel1,
+                    redirect_to=sentinel2,
+                    redirect=lambda **kwargs: FakeHttpResponse(**kwargs),
+                )
+            ).kwargs
+            == expected
+    )
+
+
+def test_redirect_to_with_reverse_lazy():
+    sentinel1, sentinel2, sentinel3, sentinel4 = object(), '/dummy/', object(), object()
+    expected = dict(redirect_to=sentinel2, request=sentinel3, form=sentinel4)
+
+    class FakeHttpResponse(HttpResponseBase):
+        # noinspection PyMissingConstructor
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    assert (
+        create_or_edit_object_redirect(
+            **merged(
+                expected,
+                is_create=sentinel1,
+                redirect_to=reverse_lazy('dummy_view'),
+                redirect=lambda **kwargs: FakeHttpResponse(**kwargs),
+            )
+        ).kwargs
         == expected
     )
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,6 +3,7 @@ from django.urls import (
     path,
 )
 
+from iommi._web_compat import HttpResponse
 from iommi.admin import Admin
 
 
@@ -11,6 +12,11 @@ class MyAdmin(Admin):
         iommi_style = 'bootstrap_docs'
 
 
+def dummy_view(request):
+    return HttpResponse('this is a dummy view')
+
+
 urlpatterns = [
+    path('dummy/', dummy_view, name='dummy_view'),
     path('admin/', include(MyAdmin.urls()))
 ]


### PR DESCRIPTION
Currently it is not possible to use `redirect_to` with `reverse_lazy`. For example, the following fails:
```python
Form.create(
    auto__model=Album,
    extra__redirect_to=reverse_lazy("album-list")
)
```
This is because `reverse_lazy` returns a string _proxy_ (an instance of `django.utils.functional.Promise`), so the [type check](https://github.com/TriOptima/iommi/blob/master/iommi/form.py#L1244) in `create_or_edit_object_redirect` fails.

This PR allows the value of `redirect_to` to be a `Promise` for a string so that the above snippet works as expected.

I haven't had time to write a test yet, but I assume one should be added in `form__tests.py`?